### PR TITLE
Remove JavaScript/TypeScript from CodeQL config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,6 @@ jobs:
           build-mode: none
         - language: rust
           build-mode: autobuild
-        - language: javascript-typescript
-          build-mode: none
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Removed JavaScript/TypeScript language configuration from CodeQL workflow.