### PR TITLE
Uninstall script + 100% audit coverage + LEGION alerts + boot-safety fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,10 @@ install-core:
 	@if [ -f "usr/share/hardn/scripts/hardn-service-manager.sh" ]; then \
 		install -m 755 usr/share/hardn/scripts/hardn-service-manager.sh "$(DESTDIR)$(LIBDIR)/hardn-service-manager"; \
 	fi
+	@install -d "$(DESTDIR)/usr/share/hardn/scripts"
+	@if [ -f "usr/share/hardn/scripts/hardn-uninstall.sh" ]; then \
+		install -m 755 usr/share/hardn/scripts/hardn-uninstall.sh "$(DESTDIR)/usr/share/hardn/scripts/hardn-uninstall.sh"; \
+	fi
 
 	@ln -sf "$(LIBDIR)/hardn"           "$(DESTDIR)$(BINDIR)/hardn"
 	@ln -sf "$(LIBDIR)/hardn-monitor"   "$(DESTDIR)$(BINDIR)/hardn-monitor"

--- a/debian/postinst
+++ b/debian/postinst
@@ -158,9 +158,20 @@ export HARDN_TOOL_PATH=\"${TOOL_DIR}:${LEGACY_TOOL_DIR}\"
         # Reload and enable systemd services updated 
         if command -v systemctl >/dev/null 2>&1 && systemctl is-system-running >/dev/null 2>&1 || [ "${container:-}" != "docker" ]; then
             systemctl daemon-reload || true
-            # Enable services in dependency order
+            # On upgrades from prior HARDN versions that enabled both
+            # hardn.service AND legion-daemon.service, the two would race on
+            # the baseline SQLite DB. Migrate any such install to the single
+            # hardn.service entry.
+            if systemctl is-enabled legion-daemon.service >/dev/null 2>&1; then
+                systemctl disable --now legion-daemon.service || true
+            fi
+            # Enable services in dependency order. legion-daemon.service is
+            # intentionally NOT enabled — hardn.service runs the same legion
+            # daemon, and the two conflict on the baseline SQLite DB. Operators
+            # who want to swap to the response-disabled variant can:
+            #   systemctl disable hardn.service
+            #   systemctl enable --now legion-daemon.service
             systemctl enable hardn.service || true
-            systemctl enable legion-daemon.service || true
             systemctl enable hardn-api.service || true
             systemctl enable hardn-monitor.service || true
         else

--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,8 @@ override_dh_auto_install:
 	install -m 644 src/hardn-api.py debian/hardn/usr/share/hardn/src/
 	# Install service manager
 	install -m 755 usr/share/hardn/scripts/hardn-service-manager.sh debian/hardn/usr/bin/hardn-service-manager
+	# Install uninstall script
+	install -m 755 usr/share/hardn/scripts/hardn-uninstall.sh debian/hardn/usr/share/hardn/scripts/hardn-uninstall.sh
 	# Install config
 	install -d debian/hardn/etc/aide
 	install -m 644 etc/aide/aide.conf debian/hardn/etc/aide/ 2>/dev/null || true

--- a/src/audit/hardn_audit.c
+++ b/src/audit/hardn_audit.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #define _DEFAULT_SOURCE
+#define _GNU_SOURCE
 
 /// This file is an openscap based compliance module for internal auditing 
 
@@ -7,6 +8,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
+#include <ftw.h>
 #include <limits.h>
 #include <pwd.h>
 #include <grp.h>
@@ -2830,6 +2832,515 @@ static rule_result_t check_rsyslog_remote_loghost(const rule_definition_t *rule)
     return fail_evidence("no rsyslog remote-forward rule found");
 }
 
+/* ---------- Firewall loopback traffic rules ---------- */
+
+static rule_result_t check_xtables_loopback(const char *const *bins, const char *family) {
+    const char *bin = first_executable(bins);
+    if (!bin) return na_evidence("%s binary not present", family);
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s -L INPUT -n -v 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return check_error("command too long");
+    char out[16384];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) {
+        return check_error("popen failed");
+    }
+    if (out[0] == '\0') {
+        return check_error("no output from iptables (run as root)");
+    }
+    /* Expect an INPUT ACCEPT rule with in iface "lo". iptables -v output
+     * prints the iface column as the source iface (5th column). We match
+     * the substring " lo " (surrounded by whitespace) on an ACCEPT line. */
+    char *saveptr = NULL;
+    bool found = false;
+    char *line;
+    for (line = strtok_r(out, "\n", &saveptr); line; line = strtok_r(NULL, "\n", &saveptr)) {
+        if (!strstr(line, "ACCEPT")) continue;
+        if (strstr(line, " lo ")) { found = true; break; }
+    }
+    if (found) {
+        return pass_evidence("%s INPUT has ACCEPT rule for lo", family);
+    }
+    return fail_evidence("%s INPUT has no ACCEPT rule for loopback (lo)", family);
+}
+
+static rule_result_t check_set_loopback_traffic(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/iptables", "/sbin/iptables", NULL };
+    return check_xtables_loopback(bins, "iptables");
+}
+
+static rule_result_t check_set_ipv6_loopback_traffic(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/ip6tables", "/sbin/ip6tables", NULL };
+    return check_xtables_loopback(bins, "ip6tables");
+}
+
+static rule_result_t check_set_ufw_loopback_traffic(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/ufw", "/sbin/ufw", "/usr/bin/ufw", NULL };
+    const char *bin = first_executable(bins);
+    if (!bin) return na_evidence("ufw binary not present");
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s status verbose 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return check_error("command too long");
+    char out[16384];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) {
+        return check_error("popen failed");
+    }
+    /* ufw allow on lo is implicit when status is active; explicit "allow in on lo"
+     * may also appear. Treat status=active with no deny-lo rule as pass. */
+    if (strstr(out, "Status: inactive")) {
+        return fail_evidence("ufw inactive — loopback not protected");
+    }
+    if (strstr(out, "Anywhere on lo") || strstr(out, "ALLOW IN") || strstr(out, "Status: active")) {
+        return pass_evidence("ufw allows loopback (implicit when active)");
+    }
+    return fail_evidence("ufw status did not confirm loopback allow");
+}
+
+static rule_result_t check_set_nftables_loopback_traffic(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", NULL };
+    const char *bin = first_executable(bins);
+    if (!bin) return na_evidence("nft binary not present");
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s list ruleset 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return check_error("command too long");
+    char out[65536];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) {
+        return check_error("popen failed");
+    }
+    if (out[0] == '\0') {
+        return fail_evidence("no nftables ruleset present");
+    }
+    /* Look for "iif lo accept" or "iif \"lo\" accept" on an input chain. */
+    if (strstr(out, "iif lo accept") || strstr(out, "iif \"lo\" accept")) {
+        return pass_evidence("nftables accepts traffic on loopback");
+    }
+    return fail_evidence("nftables ruleset has no 'iif lo accept' rule");
+}
+
+/* ---------- nftables structural ---------- */
+
+static int nft_list_ruleset(char *out, size_t out_size) {
+    static const char *bins[] = { "/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", NULL };
+    const char *bin = first_executable(bins);
+    if (!bin) return -1;
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s list ruleset 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return -1;
+    return popen_capture(cmd, out, out_size);
+}
+
+static rule_result_t check_set_nftables_table(const rule_definition_t *rule) {
+    (void)rule;
+    char out[65536];
+    if (nft_list_ruleset(out, sizeof(out)) == -1) {
+        return na_evidence("nft binary not present");
+    }
+    /* Any line starting with "table" indicates a defined table. */
+    char *saveptr = NULL;
+    char *line;
+    for (line = strtok_r(out, "\n", &saveptr); line; line = strtok_r(NULL, "\n", &saveptr)) {
+        const char *p = line;
+        while (*p && isspace((unsigned char)*p)) p++;
+        if (strncmp(p, "table ", 6) == 0) {
+            return pass_evidence("nftables table declared: %s", p);
+        }
+    }
+    return fail_evidence("no nftables table found in ruleset");
+}
+
+static rule_result_t check_set_nftables_base_chain(const rule_definition_t *rule) {
+    (void)rule;
+    char out[65536];
+    if (nft_list_ruleset(out, sizeof(out)) == -1) {
+        return na_evidence("nft binary not present");
+    }
+    if (strstr(out, "type filter hook input")) {
+        return pass_evidence("nftables base chain with hook input present");
+    }
+    return fail_evidence("no base chain with 'type filter hook input' found");
+}
+
+static rule_result_t check_nftables_rules_permanent(const rule_definition_t *rule) {
+    (void)rule;
+    /* On Debian/Ubuntu, nftables persistence is provided by either
+     * /etc/nftables.conf (loaded by nftables.service) or a snippet in
+     * /etc/nftables.d/. We accept either: file present AND non-empty,
+     * AND nftables.service is enabled. */
+    struct stat st;
+    bool conf_present = false;
+    if (stat("/etc/nftables.conf", &st) == 0 && st.st_size > 0) conf_present = true;
+    if (!conf_present) {
+        DIR *d = opendir("/etc/nftables.d");
+        if (d) {
+            struct dirent *ent;
+            while ((ent = readdir(d)) != NULL) {
+                if (ent->d_name[0] == '.') continue;
+                conf_present = true;
+                break;
+            }
+            closedir(d);
+        }
+    }
+    if (!conf_present) {
+        return fail_evidence("no /etc/nftables.conf or /etc/nftables.d entries");
+    }
+    char unit_state[64];
+    if (systemctl_query("is-enabled", "nftables.service", unit_state, sizeof(unit_state)) != 0) {
+        return pass_evidence("nftables config present (systemctl unavailable)");
+    }
+    if (unit_state[0] == '\0' || strcmp(unit_state, "not-found") == 0) {
+        return fail_evidence("nftables config present but nftables.service is not installed");
+    }
+    if (strcmp(unit_state, "enabled") == 0 || strcmp(unit_state, "static") == 0) {
+        return pass_evidence("nftables config present and unit %s", unit_state);
+    }
+    return fail_evidence("nftables config present but unit is %s", unit_state);
+}
+
+/* ---------- Listening ports cross-checked against firewall ---------- */
+
+/* Collect listening TCP ports from `ss -lnt`. Output looks like:
+ *   State  Recv-Q  Send-Q  Local Address:Port  Peer Address:Port
+ *   LISTEN 0       128     0.0.0.0:22          0.0.0.0:*
+ * We extract the port from the Local Address column. v6 entries appear as
+ * `[::]:8000`, which we strip the brackets from.
+ */
+static int collect_listening_tcp_ports(int *ports, size_t cap, size_t *count_out, bool ipv6) {
+    static const char *bins[] = { "/usr/bin/ss", "/bin/ss", "/usr/sbin/ss", "/sbin/ss", NULL };
+    const char *bin = first_executable(bins);
+    if (!bin) return -1;
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s -lntH 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return -1;
+    char out[32768];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) return -1;
+    size_t count = 0;
+    char *saveptr = NULL;
+    char *line;
+    for (line = strtok_r(out, "\n", &saveptr); line; line = strtok_r(NULL, "\n", &saveptr)) {
+        /* Skip header */
+        if (strncmp(line, "State", 5) == 0) continue;
+        /* Tokenize on whitespace, take the 4th column (Local Address:Port) */
+        char *tok_save = NULL;
+        char *t = strtok_r(line, " \t", &tok_save);
+        int col = 0;
+        char *local = NULL;
+        while (t) {
+            col++;
+            if (col == 4) { local = t; break; }
+            t = strtok_r(NULL, " \t", &tok_save);
+        }
+        if (!local) continue;
+        bool is_v6 = (local[0] == '[');
+        if (is_v6 != ipv6) continue;
+        /* Find the last ':' before the port */
+        char *colon = strrchr(local, ':');
+        if (!colon) continue;
+        long port = strtol(colon + 1, NULL, 10);
+        if (port <= 0 || port > 65535) continue;
+        if (count < cap) {
+            ports[count++] = (int)port;
+        }
+    }
+    *count_out = count;
+    return 0;
+}
+
+static rule_result_t check_xtables_ports_have_rules(const char *const *bins, const char *family, bool ipv6) {
+    const char *bin = first_executable(bins);
+    if (!bin) return na_evidence("%s binary not present", family);
+
+    int ports[256];
+    size_t port_count = 0;
+    if (collect_listening_tcp_ports(ports, sizeof(ports) / sizeof(ports[0]), &port_count, ipv6) != 0) {
+        return check_error("unable to enumerate listening ports (ss missing?)");
+    }
+    if (port_count == 0) {
+        return pass_evidence("no listening %s ports to verify", family);
+    }
+
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s -S 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return check_error("command too long");
+    char out[65536];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) {
+        return check_error("popen failed");
+    }
+    if (out[0] == '\0') {
+        return check_error("no output from %s -S (run as root)");
+    }
+
+    /* For each port, check if there's a rule containing "dport <port>" or "--dport <port>". */
+    for (size_t i = 0; i < port_count; ++i) {
+        char needle[32];
+        snprintf(needle, sizeof(needle), "dport %d", ports[i]);
+        if (!strstr(out, needle)) {
+            char alt[32];
+            snprintf(alt, sizeof(alt), "--dport %d", ports[i]);
+            if (!strstr(out, alt)) {
+                return fail_evidence("%s port %d has no firewall rule", family, ports[i]);
+            }
+        }
+    }
+    return pass_evidence("all %zu listening %s port(s) covered by firewall", port_count, family);
+}
+
+static rule_result_t check_iptables_rules_for_open_ports(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/iptables", "/sbin/iptables", NULL };
+    return check_xtables_ports_have_rules(bins, "iptables", false);
+}
+
+static rule_result_t check_ip6tables_rules_for_open_ports(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/ip6tables", "/sbin/ip6tables", NULL };
+    return check_xtables_ports_have_rules(bins, "ip6tables", true);
+}
+
+static rule_result_t check_ufw_rules_for_open_ports(const rule_definition_t *rule) {
+    (void)rule;
+    static const char *bins[] = { "/usr/sbin/ufw", "/sbin/ufw", "/usr/bin/ufw", NULL };
+    const char *bin = first_executable(bins);
+    if (!bin) return na_evidence("ufw binary not present");
+
+    int ports[256];
+    size_t port_count = 0;
+    if (collect_listening_tcp_ports(ports, sizeof(ports) / sizeof(ports[0]), &port_count, false) != 0) {
+        return check_error("unable to enumerate listening ports");
+    }
+    if (port_count == 0) {
+        return pass_evidence("no listening ports to verify");
+    }
+
+    char cmd[256];
+    int n = snprintf(cmd, sizeof(cmd), "%s status 2>/dev/null", bin);
+    if (n < 0 || (size_t)n >= sizeof(cmd)) return check_error("command too long");
+    char out[16384];
+    if (popen_capture(cmd, out, sizeof(out)) == -1) return check_error("popen failed");
+    if (strstr(out, "Status: inactive")) {
+        return fail_evidence("ufw inactive — no rules enforced");
+    }
+
+    for (size_t i = 0; i < port_count; ++i) {
+        /* ufw status shows rules like "22/tcp ALLOW Anywhere" */
+        char needle[32];
+        snprintf(needle, sizeof(needle), "%d/tcp", ports[i]);
+        if (!strstr(out, needle)) {
+            return fail_evidence("ufw has no rule for listening port %d/tcp", ports[i]);
+        }
+    }
+    return pass_evidence("all %zu listening port(s) covered by ufw", port_count);
+}
+
+/* ---------- Filesystem walks: world-writable, unowned, ungroupowned ----------
+ *
+ * One nftw-based walker visits the filesystem rooted at "/", skips
+ * pseudo-filesystems (/proc, /sys, /dev, /run) and network mounts (nfs,
+ * fuse, cifs), and for each regular file or directory invokes the supplied
+ * predicate. The walk stops at the first FAIL or after a hard cap on visited
+ * inodes to keep audit time predictable.
+ */
+
+#define FS_WALK_MAX_INODES 250000
+
+typedef enum {
+    FS_FAIL_NONE,
+    FS_FAIL_WORLD_WRITABLE,
+    FS_FAIL_UNOWNED_USER,
+    FS_FAIL_UNOWNED_GROUP,
+} fs_fail_kind_t;
+
+typedef struct {
+    fs_fail_kind_t fail_kind;
+    char offending_path[PATH_MAX];
+    size_t visited;
+    fs_fail_kind_t target;
+} fs_walk_ctx_t;
+
+static fs_walk_ctx_t g_fs_ctx;
+
+static bool path_is_skipped(const char *path) {
+    /* Skip kernel and runtime pseudo-filesystems and obvious noise. */
+    static const char *prefixes[] = {
+        "/proc/", "/sys/", "/dev/", "/run/", "/var/run/",
+        "/snap/", "/var/lib/docker/", "/var/lib/containers/",
+        "/var/lib/lxd/", "/var/lib/lxc/",
+        NULL,
+    };
+    for (size_t i = 0; prefixes[i]; ++i) {
+        size_t plen = strlen(prefixes[i]);
+        if (strncmp(path, prefixes[i], plen) == 0) return true;
+    }
+    return false;
+}
+
+static int fs_walk_visitor(const char *fpath, const struct stat *sb,
+                           int typeflag, struct FTW *ftwbuf) {
+    (void)ftwbuf;
+    if (path_is_skipped(fpath)) return FTW_SKIP_SUBTREE;
+    if (g_fs_ctx.visited++ > FS_WALK_MAX_INODES) return FTW_STOP;
+
+    if (typeflag != FTW_F && typeflag != FTW_D) return FTW_CONTINUE;
+
+    switch (g_fs_ctx.target) {
+        case FS_FAIL_WORLD_WRITABLE:
+            /* World-writable AND not sticky (sticky on dirs like /tmp is fine).
+             * Symlinks excluded — they're never traversed by nftw without FOLLOW. */
+            if ((sb->st_mode & S_IWOTH) && !(sb->st_mode & S_ISVTX)) {
+                g_fs_ctx.fail_kind = FS_FAIL_WORLD_WRITABLE;
+                snprintf(g_fs_ctx.offending_path, sizeof(g_fs_ctx.offending_path),
+                         "%s", fpath);
+                return FTW_STOP;
+            }
+            break;
+        case FS_FAIL_UNOWNED_USER:
+            if (getpwuid(sb->st_uid) == NULL) {
+                g_fs_ctx.fail_kind = FS_FAIL_UNOWNED_USER;
+                snprintf(g_fs_ctx.offending_path, sizeof(g_fs_ctx.offending_path),
+                         "%s (uid=%u)", fpath, (unsigned)sb->st_uid);
+                return FTW_STOP;
+            }
+            break;
+        case FS_FAIL_UNOWNED_GROUP:
+            if (getgrgid(sb->st_gid) == NULL) {
+                g_fs_ctx.fail_kind = FS_FAIL_UNOWNED_GROUP;
+                snprintf(g_fs_ctx.offending_path, sizeof(g_fs_ctx.offending_path),
+                         "%s (gid=%u)", fpath, (unsigned)sb->st_gid);
+                return FTW_STOP;
+            }
+            break;
+        case FS_FAIL_NONE:
+            break;
+    }
+    return FTW_CONTINUE;
+}
+
+static rule_result_t run_fs_walk(fs_fail_kind_t target, const char *pass_msg, const char *fail_label) {
+    g_fs_ctx.fail_kind = FS_FAIL_NONE;
+    g_fs_ctx.offending_path[0] = '\0';
+    g_fs_ctx.visited = 0;
+    g_fs_ctx.target = target;
+
+    /* FTW_PHYS = don't follow symlinks. FTW_MOUNT = don't cross mountpoints
+     * (skips network mounts, /proc submounts, etc. without us having to
+     * enumerate them). FTW_ACTIONRETVAL = honor FTW_SKIP_SUBTREE / FTW_STOP. */
+    int flags = FTW_PHYS | FTW_MOUNT | FTW_ACTIONRETVAL;
+    int rc = nftw("/", fs_walk_visitor, 64, flags);
+    if (rc < 0) return check_error("nftw walk failed");
+
+    if (g_fs_ctx.visited > FS_WALK_MAX_INODES) {
+        return na_evidence("walk exceeded %d inodes — partial scan only", FS_WALK_MAX_INODES);
+    }
+    if (g_fs_ctx.fail_kind != FS_FAIL_NONE) {
+        return fail_evidence("%s: %s", fail_label, g_fs_ctx.offending_path);
+    }
+    return pass_evidence("%s (scanned %zu paths)", pass_msg, g_fs_ctx.visited);
+}
+
+static rule_result_t check_file_permissions_unauthorized_world_writable(const rule_definition_t *rule) {
+    (void)rule;
+    return run_fs_walk(FS_FAIL_WORLD_WRITABLE,
+                       "no unauthorized world-writable files",
+                       "world-writable without sticky");
+}
+
+static rule_result_t check_no_files_unowned_by_user(const rule_definition_t *rule) {
+    (void)rule;
+    return run_fs_walk(FS_FAIL_UNOWNED_USER,
+                       "every file owned by a valid user",
+                       "file with unknown user");
+}
+
+static rule_result_t check_file_permissions_ungroupowned(const rule_definition_t *rule) {
+    (void)rule;
+    return run_fs_walk(FS_FAIL_UNOWNED_GROUP,
+                       "every file owned by a valid group",
+                       "file with unknown group");
+}
+
+/* ---------- PATH directory writability ---------- */
+
+static bool dir_is_world_or_group_writable(const char *path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return false;
+    if (!S_ISDIR(st.st_mode)) return false;
+    return (st.st_mode & (S_IWGRP | S_IWOTH)) != 0;
+}
+
+/* Extract PATH= entries from a shell rc file and return the first unsafe
+ * directory found, or NULL if all entries are safe. Caller-owned static
+ * buffer reused on each call. */
+static const char *find_unsafe_path_dir_in_shell_file(const char *file) {
+    static char offender[PATH_MAX];
+    offender[0] = '\0';
+    char **lines = NULL;
+    size_t count = 0;
+    if (load_file_lines(file, &lines, &count) != 0) return NULL;
+    for (size_t i = 0; i < count; ++i) {
+        char *p = lines[i];
+        while (isspace((unsigned char)*p)) p++;
+        if (*p == '#' || *p == '\0') continue;
+        const char *eq = strstr(p, "PATH=");
+        if (!eq) continue;
+        const char *val = eq + 5;
+        if (*val == '"' || *val == '\'') val++;
+        const char *cursor = val;
+        while (*cursor && *cursor != '"' && *cursor != '\'' && *cursor != ' ' && *cursor != '\t') {
+            const char *colon = strchr(cursor, ':');
+            size_t len = colon ? (size_t)(colon - cursor) : strlen(cursor);
+            if (len > 0 && len < sizeof(offender)) {
+                char dir[PATH_MAX];
+                memcpy(dir, cursor, len);
+                dir[len] = '\0';
+                if (dir[0] == '/' && dir_is_world_or_group_writable(dir)) {
+                    snprintf(offender, sizeof(offender), "%.512s in %.512s", dir, file);
+                    free_lines(lines, count);
+                    return offender;
+                }
+            }
+            cursor += len;
+            if (!*cursor || *cursor != ':') break;
+            cursor++;
+        }
+    }
+    free_lines(lines, count);
+    return NULL;
+}
+
+static rule_result_t check_accounts_root_path_dirs_no_write(const rule_definition_t *rule) {
+    (void)rule;
+    const char *paths[] = { "/root/.bashrc", "/root/.profile", "/root/.bash_profile", NULL };
+    for (size_t i = 0; paths[i]; ++i) {
+        const char *off = find_unsafe_path_dir_in_shell_file(paths[i]);
+        if (off) return fail_evidence("root PATH entry is writable: %s", off);
+    }
+    return pass_evidence("root PATH contains no writable directories");
+}
+
+static rule_result_t per_user_dot_no_writable_path(const struct passwd *pw) {
+    if (!pw->pw_dir || !*pw->pw_dir) return pass_evidence("%s no home", pw->pw_name);
+    const char *dotfiles[] = {
+        ".bashrc", ".bash_profile", ".bash_login", ".profile",
+        ".zshrc", ".cshrc", ".tcshrc", ".login", ".kshrc", NULL
+    };
+    for (size_t i = 0; dotfiles[i]; ++i) {
+        char path[PATH_MAX];
+        int n = snprintf(path, sizeof(path), "%s/%s", pw->pw_dir, dotfiles[i]);
+        if (n < 0 || (size_t)n >= sizeof(path)) continue;
+        const char *off = find_unsafe_path_dir_in_shell_file(path);
+        if (off) return fail_evidence("user %s PATH entry writable: %s", pw->pw_name, off);
+    }
+    return pass_evidence("user %s init dotfiles have safe PATH entries", pw->pw_name);
+}
+
+static rule_result_t check_accounts_user_dot_no_world_writable_programs(const rule_definition_t *rule) {
+    (void)rule;
+    return for_each_interactive_user(per_user_dot_no_writable_path);
+}
+
 ////////////// Rule table
 
 #define RULE_DEF(ID, TITLE, CATEGORY, SEVERITY, CHECK) \
@@ -3087,6 +3598,31 @@ static void initialize_rule_overrides(void) {
 
     /* /var/log permissions tree walk */
     patch_rule_check("xccdf_org.ssgproject.content_rule_permissions_local_var_log", check_permissions_local_var_log);
+
+    /* Loopback firewall traffic */
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_loopback_traffic", check_set_loopback_traffic);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_ipv6_loopback_traffic", check_set_ipv6_loopback_traffic);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_ufw_loopback_traffic", check_set_ufw_loopback_traffic);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_nftables_loopback_traffic", check_set_nftables_loopback_traffic);
+
+    /* nftables structural */
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_nftables_table", check_set_nftables_table);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_set_nftables_base_chain", check_set_nftables_base_chain);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_nftables_rules_permanent", check_nftables_rules_permanent);
+
+    /* Listening ports cross-checked against firewall rules */
+    patch_rule_check("xccdf_org.ssgproject.content_rule_iptables_rules_for_open_ports", check_iptables_rules_for_open_ports);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_ip6tables_rules_for_open_ports", check_ip6tables_rules_for_open_ports);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_ufw_rules_for_open_ports", check_ufw_rules_for_open_ports);
+
+    /* Filesystem walks */
+    patch_rule_check("xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable", check_file_permissions_unauthorized_world_writable);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_no_files_unowned_by_user", check_no_files_unowned_by_user);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned", check_file_permissions_ungroupowned);
+
+    /* PATH dir writability */
+    patch_rule_check("xccdf_org.ssgproject.content_rule_accounts_root_path_dirs_no_write", check_accounts_root_path_dirs_no_write);
+    patch_rule_check("xccdf_org.ssgproject.content_rule_accounts_user_dot_no_world_writable_programs", check_accounts_user_dot_no_world_writable_programs);
 }
 
 int main(void) {

--- a/src/hardn-monitor.rs
+++ b/src/hardn-monitor.rs
@@ -8,6 +8,10 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
+#[path = "utils/alerts.rs"]
+mod alerts;
+use alerts::emit_alert;
+
 fn log_message(level: &str, message: &str) {
     let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S");
     let log_entry = format!("[{}] [{}] {}\n", timestamp, level, message);
@@ -26,67 +30,6 @@ fn log_message(level: &str, message: &str) {
 
     // Also log to stderr for systemd
     eprintln!("{}", log_entry.trim());
-}
-
-/// Build the JSON-lines payload for one alert. Separated from the file I/O
-/// so it can be unit-tested without touching /var/log/hardn.
-fn build_alert_payload(ts: &str, severity: &str, source: &str, message: &str, key: &str) -> String {
-    serde_json::json!({
-        "ts": ts,
-        "severity": severity,
-        "source": source,
-        "message": message,
-        "key": key,
-    })
-    .to_string()
-}
-
-/// Append one JSON-lines alert record to /var/log/hardn/alerts.jsonl.
-///
-/// The GUI tails this file and renders alerts in a dedicated panel. `key`
-/// lets the GUI deduplicate repeats of the same condition (e.g. a service
-/// being down across many poll cycles produces one alert row, updated in
-/// place rather than appended).
-fn emit_alert(severity: &str, source: &str, message: &str, key: &str) {
-    let _ = fs::create_dir_all("/var/log/hardn");
-    let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let payload = build_alert_payload(&ts, severity, source, message, key);
-    if let Ok(mut f) = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/var/log/hardn/alerts.jsonl")
-    {
-        let _ = writeln!(f, "{}", payload);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn alert_payload_is_valid_json_with_expected_fields() {
-        let s = build_alert_payload(
-            "2026-05-24T00:00:00Z",
-            "warning",
-            "hardn-monitor",
-            "hardn.service is stopped",
-            "svc-down:hardn.service",
-        );
-        let v: serde_json::Value = serde_json::from_str(&s).expect("must parse");
-        assert_eq!(v["ts"], "2026-05-24T00:00:00Z");
-        assert_eq!(v["severity"], "warning");
-        assert_eq!(v["source"], "hardn-monitor");
-        assert_eq!(v["message"], "hardn.service is stopped");
-        assert_eq!(v["key"], "svc-down:hardn.service");
-    }
-
-    #[test]
-    fn alert_payload_escapes_quotes_and_newlines() {
-        let s = build_alert_payload("t", "info", "src", "line with \"quote\" and\nnewline", "k");
-        let v: serde_json::Value = serde_json::from_str(&s).expect("must parse");
-        assert_eq!(v["message"], "line with \"quote\" and\nnewline");
-    }
 }
 
 fn check_service_status(service: &str) -> Result<String, std::io::Error> {

--- a/src/legion/core/legion.rs
+++ b/src/legion/core/legion.rs
@@ -12,6 +12,7 @@ use super::framework_pipeline;
 use crate::core::config::{DEFAULT_LIB_DIR, DEFAULT_LOG_DIR};
 use crate::core::cron::CronOrchestrator;
 use crate::legion::functions;
+use crate::utils::emit_alert;
 use crate::legion::modules::auth::auth as auth_mod;
 use crate::legion::modules::behavioral::{
     BehaviorClassification, BehavioralAnalyzer, ProcessBehavior,
@@ -30,7 +31,7 @@ use crate::legion::modules::permissions::permissions as permissions_mod;
 use crate::legion::modules::processes::processes as processes_mod;
 use crate::legion::modules::response::{Anomaly, ResponseAction, ResponseEngine};
 use crate::legion::modules::risk_scoring::{
-    BaselineDriftSummary, RiskScore, RiskScoringManager, ScriptResult, ScriptStatus,
+    BaselineDriftSummary, RiskLevel, RiskScore, RiskScoringManager, ScriptResult, ScriptStatus,
     SecurityPlatformStatus, SystemState, ThreatIndicator as RiskThreatIndicator,
 };
 use crate::legion::modules::services as services_mod;
@@ -912,8 +913,45 @@ impl Legion {
                     }
                 }
 
+                // Surface high-risk cycles into the alert channel so the GUI
+                // shows them. Dedup key is the risk level so a sustained
+                // high-risk state shows as one updating row, not a stream.
+                match risk_score.risk_level {
+                    RiskLevel::Critical | RiskLevel::High => {
+                        let severity = if matches!(risk_score.risk_level, RiskLevel::Critical) {
+                            "critical"
+                        } else {
+                            "error"
+                        };
+                        let top_factor = risk_score
+                            .contributing_factors
+                            .first()
+                            .map(|s| s.as_str())
+                            .unwrap_or("no factor reported");
+                        emit_alert(
+                            severity,
+                            "legion",
+                            &format!(
+                                "Risk level {} (score {:.3}) — {}",
+                                risk_score.risk_level, risk_score.overall_score, top_factor
+                            ),
+                            &format!("legion-risk:{}", risk_score.risk_level),
+                        );
+                    }
+                    _ => {}
+                }
+
                 // Execute automated responses if enabled
                 if self.response_enabled && risk_score.overall_score > 0.7 {
+                    emit_alert(
+                        "warning",
+                        "legion",
+                        &format!(
+                            "Automated response triggered at risk {:.3}",
+                            risk_score.overall_score
+                        ),
+                        "legion-response-triggered",
+                    );
                     self.execute_automated_response(&risk_score).await?;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1764,6 +1764,43 @@ fn enable_selinux() -> i32 {
     }
 }
 
+/// Run the HARDN uninstall script. Any args after `--uninstall` are passed
+/// through to the script (e.g. `hardn --uninstall --yes --restore-ssh`).
+/// The script itself prompts for confirmation when run interactively
+/// without `--yes`, so we don't add a second prompt here.
+fn uninstall_hardn(args: &[String]) -> i32 {
+    let candidates = [
+        "/usr/share/hardn/scripts/hardn-uninstall.sh",
+        "/usr/local/share/hardn/scripts/hardn-uninstall.sh",
+    ];
+    let script = match candidates.iter().find(|p| Path::new(p).exists()) {
+        Some(p) => *p,
+        None => {
+            log_message(
+                LogLevel::Error,
+                "hardn-uninstall.sh not found in /usr/share/hardn/scripts",
+            );
+            return EXIT_FAILURE;
+        }
+    };
+
+    let pass_through: Vec<&str> = args.iter().skip(2).map(|s| s.as_str()).collect();
+    log_message(
+        LogLevel::Warning,
+        &format!("Invoking {} {}", script, pass_through.join(" ")),
+    );
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(script).args(&pass_through);
+    match cmd.status() {
+        Ok(status) => status.code().unwrap_or(EXIT_FAILURE),
+        Err(e) => {
+            log_message(LogLevel::Error, &format!("Failed to run uninstall: {}", e));
+            EXIT_FAILURE
+        }
+    }
+}
+
 /// Disable sandbox mode - restore network configuration
 /// IMPORTANT: This function is ONLY called directly via --sandbox-off flag
 /// It is NEVER included in batch operations (--run-all-modules, --run-all-tools, --run-everything)
@@ -3033,6 +3070,7 @@ AVAILABLE COMMANDS:
   run-tool <name>          Run specific security tool
   legion <options>         LEGION security monitoring
   --security-report        Generate comprehensive security assessment
+  --uninstall [flags]      Uninstall HARDN (see --uninstall --help for flags)
 
 ═══════════════════════════════════════════════════════════════════════════════
 "#,
@@ -3175,6 +3213,8 @@ fn main() {
 
     let exit_code = if args.len() >= 2 && (args[1] == "legion" || args[1] == "--legion") {
         run_legion(&args)
+    } else if args.len() >= 2 && (args[1] == "--uninstall" || args[1] == "uninstall") {
+        uninstall_hardn(&args)
     } else {
         match args.len() {
             1 => {

--- a/src/utils/alerts.rs
+++ b/src/utils/alerts.rs
@@ -1,0 +1,110 @@
+//! Shared alert emission for the HARDN alert channel.
+//!
+//! Alerts are appended as JSON lines to `/var/log/hardn/alerts.jsonl`.
+//! `hardn-gui` tails this file and shows alerts in a dedicated panel,
+//! deduplicating repeats of the same condition by the `key` field.
+//!
+//! Producers:
+//! - `hardn-monitor` (service down / restart success / restart failure)
+//! - `hardn legion` daemon (risk threshold breaches, automated response)
+//!
+//! The protocol field set is intentionally small: `ts`, `severity`,
+//! `source`, `message`, `key`. Severities used today: `info`, `warning`,
+//! `error`, `critical`.
+
+use chrono::Utc;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Default path for the alert sink. Producers can override via
+/// `emit_alert_to` if they need a different location (e.g. tests).
+pub const DEFAULT_ALERTS_PATH: &str = "/var/log/hardn/alerts.jsonl";
+
+/// Build one JSON-lines payload. Pure function so callers can test
+/// formatting without touching disk.
+pub fn build_alert_payload(
+    ts: &str,
+    severity: &str,
+    source: &str,
+    message: &str,
+    key: &str,
+) -> String {
+    serde_json::json!({
+        "ts": ts,
+        "severity": severity,
+        "source": source,
+        "message": message,
+        "key": key,
+    })
+    .to_string()
+}
+
+/// Append one alert to `path`. Creates parent directory and the file
+/// if missing. Errors are swallowed so the alert path never affects the
+/// caller's control flow.
+pub fn emit_alert_to(path: &Path, severity: &str, source: &str, message: &str, key: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let payload = build_alert_payload(&ts, severity, source, message, key);
+    if let Ok(mut f) = fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "{}", payload);
+    }
+}
+
+/// Convenience wrapper that emits to the default `/var/log/hardn/alerts.jsonl`.
+pub fn emit_alert(severity: &str, source: &str, message: &str, key: &str) {
+    emit_alert_to(
+        &PathBuf::from(DEFAULT_ALERTS_PATH),
+        severity,
+        source,
+        message,
+        key,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_is_valid_json_with_expected_fields() {
+        let s = build_alert_payload(
+            "2026-05-24T00:00:00Z",
+            "warning",
+            "hardn-monitor",
+            "hardn.service is stopped",
+            "svc-down:hardn.service",
+        );
+        let v: serde_json::Value = serde_json::from_str(&s).expect("must parse");
+        assert_eq!(v["ts"], "2026-05-24T00:00:00Z");
+        assert_eq!(v["severity"], "warning");
+        assert_eq!(v["source"], "hardn-monitor");
+        assert_eq!(v["message"], "hardn.service is stopped");
+        assert_eq!(v["key"], "svc-down:hardn.service");
+    }
+
+    #[test]
+    fn payload_escapes_quotes_and_newlines() {
+        let s = build_alert_payload("t", "info", "src", "line with \"quote\" and\nnewline", "k");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("must parse");
+        assert_eq!(v["message"], "line with \"quote\" and\nnewline");
+    }
+
+    #[test]
+    fn emit_alert_to_writes_one_jsonl_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("alerts.jsonl");
+        emit_alert_to(&path, "error", "test", "boom", "k1");
+        emit_alert_to(&path, "warning", "test", "weak", "k2");
+        let contents = fs::read_to_string(&path).expect("read alerts file");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let v0: serde_json::Value = serde_json::from_str(lines[0]).expect("line 0 json");
+        let v1: serde_json::Value = serde_json::from_str(lines[1]).expect("line 1 json");
+        assert_eq!(v0["severity"], "error");
+        assert_eq!(v1["severity"], "warning");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,10 @@
+pub mod alerts;
 pub mod logging;
 pub mod paths;
 pub mod system;
 
 // Re-export commonly used functions
+pub use alerts::emit_alert;
 pub use logging::{log_message, LogLevel};
 pub use paths::{env_or_defaults, find_script, join_paths, list_modules};
 pub use system::detect_debian_version;

--- a/systemd/hardn-api.service
+++ b/systemd/hardn-api.service
@@ -18,6 +18,12 @@ Environment=HARDN_API_HOST=0.0.0.0
 Environment=HARDN_API_PORT=8000
 # Authorized SSH public keys for remote API auth — one key per line
 Environment=HARDN_AUTHORIZED_KEYS=/etc/hardn/authorized_keys
+# Refuse to start the API if no authorized keys are registered. Without this
+# guard the API listens on 0.0.0.0:8000 and the UFW rule for 8000/tcp leaves
+# it reachable; the API rejects all auth but the open port is still an
+# unnecessary surface. Operators are expected to register at least one key:
+#   echo "$(cat ~/.ssh/id_ed25519.pub)" | sudo tee -a /etc/hardn/authorized_keys
+ExecStartPre=/bin/sh -c 'test -s /etc/hardn/authorized_keys || { echo "HARDN API refusing to start: /etc/hardn/authorized_keys is missing or empty. See README \"Remote Access\"." >&2; exit 1; }'
 # Use env to tolerate python3 path differences across distros after seeing issue between deb 13 and ubuntu 24.04
 ExecStart=/usr/bin/env python3 -u /usr/share/hardn/src/hardn-api.py
 

--- a/systemd/hardn.service
+++ b/systemd/hardn.service
@@ -3,6 +3,10 @@ Description=HARDN Security Monitoring and Response Service
 # Bring HARDN up after the network is actually online
 After=network-online.target
 Wants=network-online.target
+# legion-daemon.service runs the same binary against the same baseline DB.
+# We refuse to run alongside it to avoid two processes racing on the SQLite
+# WAL during schema bootstrap.
+Conflicts=legion-daemon.service
 StartLimitIntervalSec=300
 StartLimitBurst=5
 
@@ -14,9 +18,17 @@ Group=root
 # Optional, but nice for consistency if you ever add relative paths
 WorkingDirectory=/usr/share/hardn
 
+# Optional environment file for operators. Set HARDN_LEGION_EXTRA_ARGS here to
+# inject additional LEGION flags (most commonly --response-enabled). Leaving
+# the file absent means LEGION runs in observe-only mode, which is the
+# safer default and prevents auto-response actions from firing on every boot.
+EnvironmentFile=-/etc/hardn/legion.env
+
 # First run: if no LEGION baseline exists, create one, then start the daemon.
 # On subsequent restarts, it just runs the daemon.
-ExecStart=/bin/bash -c 'if [ ! -d /var/lib/hardn/legion ] || [ -z "$(ls -A /var/lib/hardn/legion/baseline_*.json 2>/dev/null)" ]; then echo "Creating LEGION baseline..."; /usr/bin/hardn legion --create-baseline --json; fi; exec /usr/bin/hardn legion --daemon --response-enabled --verbose'
+# To enable automated responses, set in /etc/hardn/legion.env:
+#   HARDN_LEGION_EXTRA_ARGS="--response-enabled"
+ExecStart=/bin/bash -c 'if [ ! -d /var/lib/hardn/legion ] || [ -z "$(ls -A /var/lib/hardn/legion/baseline_*.json 2>/dev/null)" ]; then echo "Creating LEGION baseline..."; /usr/bin/hardn legion --create-baseline --json; fi; exec /usr/bin/hardn legion --daemon --verbose ${HARDN_LEGION_EXTRA_ARGS}'
 
 # If you want it to come back even after manual stop, keep "always";
 # if you want "systemctl stop hardn" to stick, change to on-failure.

--- a/systemd/legion-daemon.service
+++ b/systemd/legion-daemon.service
@@ -1,8 +1,11 @@
 [Unit]
-Description=HARDN LEGION Security Monitoring Daemon
+Description=HARDN LEGION Security Monitoring Daemon (observe-only variant)
 # Bring LEGION up after the network is actually online
 After=network-online.target
 Wants=network-online.target
+# hardn.service is the default daemon entry; we refuse to co-exist with it
+# because both processes open the same baseline SQLite DB.
+Conflicts=hardn.service
 StartLimitIntervalSec=300
 StartLimitBurst=5
 

--- a/usr/share/hardn/scripts/hardn-service-manager.sh
+++ b/usr/share/hardn/scripts/hardn-service-manager.sh
@@ -891,11 +891,12 @@ dangerous_operations_menu() {
         echo -e "─────────────────────────────────────────────────"
         echo
         echo "1) Enable SELinux (REQUIRES REBOOT - DISABLES AppArmor)"
+        echo "2) Uninstall HARDN (remove services, drop-in configs, runtime data)"
         echo
         echo "0) Back to Main Menu"
         echo
-        read -p "Select option [0-1]: " danger_choice || { echo; return; }
-        
+        read -p "Select option [0-2]: " danger_choice || { echo; return; }
+
         case $danger_choice in
             1)
                 echo -e "\n${BOLD}${RED}EXTREME WARNING${NC}"
@@ -918,6 +919,37 @@ dangerous_operations_menu() {
                     fi
                 else
                     echo "Operation cancelled."
+                fi
+                read -p $'\nPress Enter to continue...' || true
+                ;;
+            2)
+                echo -e "\n${BOLD}${RED}HARDN UNINSTALL${NC}"
+                echo -e "${RED}This will:"
+                echo "  - Stop and disable all HARDN services"
+                echo "  - Remove HARDN drop-in config files (99-hardn-*.conf etc.)"
+                echo "  - Remove /var/log/hardn and /var/lib/hardn"
+                echo "  - Purge the hardn package"
+                echo "  - Remove the hardn system user/group"
+                echo ""
+                echo "It will NOT (unless you opt in via flags):"
+                echo "  - Re-enable SSH if HARDN disabled it"
+                echo "  - Reset the firewall (dangerous over remote SSH)"
+                echo "  - Purge installed security packages (aide, clamav, fail2ban, ...)"
+                echo -e "${NC}"
+                read -p "Type 'YES UNINSTALL' to confirm: " final_confirm || { echo; continue; }
+                if [[ "$final_confirm" == "YES UNINSTALL" ]]; then
+                    extra_flags=""
+                    read -p "Also re-enable SSH (--restore-ssh)? [y/N]: " ans
+                    [[ "$ans" =~ ^[yY] ]] && extra_flags="$extra_flags --restore-ssh"
+                    read -p "Also purge security packages (--purge-packages)? [y/N]: " ans
+                    [[ "$ans" =~ ^[yY] ]] && extra_flags="$extra_flags --purge-packages"
+                    read -p "Also reset the firewall (--reset-firewall, DANGEROUS)? [y/N]: " ans
+                    [[ "$ans" =~ ^[yY] ]] && extra_flags="$extra_flags --reset-firewall"
+                    echo -e "\n${BOLD}Running uninstall...${NC}"
+                    # shellcheck disable=SC2086
+                    "$HARDN_BIN" --uninstall --yes $extra_flags
+                else
+                    echo "Uninstall cancelled."
                 fi
                 read -p $'\nPress Enter to continue...' || true
                 ;;

--- a/usr/share/hardn/scripts/hardn-uninstall.sh
+++ b/usr/share/hardn/scripts/hardn-uninstall.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# HARDN uninstall script
+# Reverses HARDN's persistent system changes to return the host as close to
+# its pre-install state as practical. Some changes cannot be reverted from
+# userspace alone (auditd -e 2 immutable rules persist until reboot; an
+# initramfs rebuild that blacklisted firewire requires a manual rebuild).
+# Those are reported at the end so an operator can finish manually.
+#
+# Default behavior (interactive, no flags):
+#   - stop and disable HARDN services
+#   - remove HARDN-written drop-in config files (99-hardn-*.conf etc.)
+#   - re-load sysctl defaults
+#   - remove HARDN runtime data dirs
+#   - dpkg -P the hardn package
+#   - drop the hardn system user and group
+#   - print a manual-recovery summary
+#
+# Optional flags (off by default — opt-in for destructive or context-specific
+# actions):
+#   --yes                 skip confirmation prompts (unattended)
+#   --dry-run             print actions, don't execute
+#   --keep-data           keep /var/log/hardn and /var/lib/hardn
+#   --keep-keys           keep /etc/hardn/authorized_keys (for later reinstall)
+#   --restore-ssh         systemctl unmask+enable+start ssh.service
+#   --reset-firewall      ufw reset && ufw disable   (RISKY over remote SSH)
+#   --purge-packages      apt-get purge HARDN-installed security packages
+#
+# Exit codes:
+#   0  success (host returned to baseline as far as practical)
+#   1  ran but encountered partial failures (printed to stderr)
+#   2  bad invocation / aborted by user
+
+set -uo pipefail
+
+# Resolve functions.sh for HARDN_STATUS and helpers
+FUNCTIONS_SH=""
+for candidate in \
+    "$(cd "$(dirname "$0")" && pwd)/../tools/functions.sh" \
+    "/usr/share/hardn/tools/functions.sh" \
+    "/usr/local/share/hardn/tools/functions.sh"; do
+    if [ -f "$candidate" ]; then FUNCTIONS_SH="$candidate"; break; fi
+done
+
+if [ -n "$FUNCTIONS_SH" ]; then
+    # shellcheck source=/dev/null
+    source "$FUNCTIONS_SH"
+else
+    # Minimal fallback so the script still works after dpkg -P removed the libs
+    HARDN_STATUS() {
+        local level="${1:-info}"; local msg="${2:-}"
+        if [ -z "$msg" ]; then msg="$level"; level="info"; fi
+        printf '[%s] %s\n' "${level^^}" "$msg"
+    }
+fi
+
+ASSUME_YES=0
+DRY_RUN=0
+KEEP_DATA=0
+KEEP_KEYS=0
+RESTORE_SSH=0
+RESET_FIREWALL=0
+PURGE_PACKAGES=0
+
+usage() {
+    sed -n '2,/^set -uo pipefail/{/^set -uo pipefail/q;p;}' "$0"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --yes|-y)              ASSUME_YES=1 ;;
+        --dry-run)             DRY_RUN=1 ;;
+        --keep-data)           KEEP_DATA=1 ;;
+        --keep-keys)           KEEP_KEYS=1 ;;
+        --restore-ssh)         RESTORE_SSH=1 ;;
+        --reset-firewall)      RESET_FIREWALL=1 ;;
+        --purge-packages)      PURGE_PACKAGES=1 ;;
+        --help|-h)             usage; exit 0 ;;
+        *) HARDN_STATUS error "Unknown option: $arg"; usage; exit 2 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    HARDN_STATUS error "Must run as root (use sudo)."
+    exit 2
+fi
+
+# Confirmation
+if [ "$ASSUME_YES" -ne 1 ] && [ "$DRY_RUN" -ne 1 ]; then
+    cat <<'EOM'
+
+═══════════════════════════════════════════════════════════════════
+                    HARDN UNINSTALL
+═══════════════════════════════════════════════════════════════════
+
+This will:
+  - Stop and disable hardn / legion-daemon / hardn-api / hardn-monitor
+  - Remove HARDN-written drop-in config files
+  - Remove HARDN runtime data (/var/log/hardn, /var/lib/hardn)
+  - Remove the hardn system user and group
+  - Purge the hardn Debian package
+
+It will NOT (unless you pass the matching flag):
+  - Re-enable SSH (--restore-ssh)
+  - Reset the firewall (--reset-firewall — RISKY over remote SSH)
+  - Purge installed security packages like aide/clamav/fail2ban
+    (--purge-packages)
+
+Some changes cannot be fully reverted from userspace and require a
+reboot or manual action — these will be listed at the end.
+
+EOM
+    read -r -p "Type 'YES UNINSTALL' to proceed, anything else aborts: " confirm
+    if [ "$confirm" != "YES UNINSTALL" ]; then
+        HARDN_STATUS info "Aborted."
+        exit 2
+    fi
+fi
+
+run_cmd() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[dry-run] %s\n' "$*"
+    else
+        # Use bash -c so callers can pass shell metacharacters (redirects, ||)
+        # without us writing per-step error handling for every line.
+        bash -c "$*"
+    fi
+}
+
+# ---------- Step 1: stop & disable services ----------
+HARDN_STATUS info "Stopping HARDN services"
+for svc in hardn-monitor.service hardn-api.service hardn.service legion-daemon.service; do
+    if systemctl list-unit-files 2>/dev/null | grep -q "^${svc}"; then
+        run_cmd "systemctl stop ${svc} 2>/dev/null || true"
+        run_cmd "systemctl disable ${svc} 2>/dev/null || true"
+    fi
+done
+
+# ---------- Step 2: remove HARDN-written drop-in config files ----------
+HARDN_STATUS info "Removing HARDN drop-in config files"
+HARDN_OWNED_FILES=(
+    /etc/audit/rules.d/99-hardn-hardening.rules
+    /etc/sysctl.d/99-hardn-hardening.conf
+    /etc/sysctl.d/99-hardn-network-tuning.conf
+    /etc/systemd/timesyncd.conf.d/99-hardn.conf
+    /etc/systemd/journald.conf.d/99-hardn.conf
+    /etc/systemd/coredump.conf.d/99-hardn-disable.conf
+    /etc/rsyslog.d/99-hardn-remote.conf
+    /etc/sudoers.d/99-hardn-logging
+    /etc/ssh/sshd_config.d/99-hardn-hardened.conf
+    /etc/fail2ban/jail.d/99-hardn.conf
+    /etc/aide/aide.conf.d/99-hardn-fast.conf
+    /etc/logrotate.d/hardn
+    /etc/systemd/system/grafana-server.service.d/override.conf
+)
+for f in "${HARDN_OWNED_FILES[@]}"; do
+    if [ -f "$f" ]; then
+        run_cmd "rm -f '$f'"
+    fi
+done
+
+# Try to remove now-empty drop-in dirs we may have created
+for d in /etc/systemd/system/grafana-server.service.d \
+         /etc/aide/aide.conf.d; do
+    run_cmd "rmdir '$d' 2>/dev/null || true"
+done
+
+# ---------- Step 3: remove HARDN-added APT repos & keys ----------
+HARDN_STATUS info "Removing HARDN-added APT repositories and keys"
+for f in /etc/apt/sources.list.d/grafana.list \
+         /etc/apt/sources.list.d/wazuh.list \
+         /etc/apt/keyrings/grafana.gpg \
+         /etc/apt/keyrings/wazuh.gpg; do
+    [ -f "$f" ] && run_cmd "rm -f '$f'"
+done
+
+# ---------- Step 4: reload runtime defaults ----------
+HARDN_STATUS info "Reloading sysctl, systemd, audit defaults"
+run_cmd "systemctl daemon-reload 2>/dev/null || true"
+run_cmd "sysctl --system >/dev/null 2>&1 || true"
+# augenrules --load will fail if auditd ran -e 2 — that's expected, noted later
+run_cmd "augenrules --load 2>/dev/null || true"
+
+# ---------- Step 5: optional SSH restore ----------
+if [ "$RESTORE_SSH" -eq 1 ]; then
+    HARDN_STATUS info "Re-enabling SSH"
+    if systemctl list-unit-files 2>/dev/null | grep -q '^ssh\.service'; then
+        run_cmd "systemctl unmask ssh.service 2>/dev/null || true"
+        run_cmd "systemctl enable --now ssh.service 2>/dev/null || true"
+    fi
+    if systemctl list-unit-files 2>/dev/null | grep -q '^ssh\.socket'; then
+        run_cmd "systemctl unmask ssh.socket 2>/dev/null || true"
+        run_cmd "systemctl enable --now ssh.socket 2>/dev/null || true"
+    fi
+else
+    HARDN_STATUS info "Leaving SSH state as-is (pass --restore-ssh to unmask + enable)"
+fi
+
+# ---------- Step 6: optional firewall reset ----------
+if [ "$RESET_FIREWALL" -eq 1 ]; then
+    HARDN_STATUS warning "Resetting UFW (this can cut a remote SSH session if SSH isn't allowed in the new state)"
+    if command -v ufw >/dev/null 2>&1; then
+        run_cmd "ufw --force reset >/dev/null 2>&1 || true"
+        run_cmd "ufw --force disable >/dev/null 2>&1 || true"
+    fi
+else
+    HARDN_STATUS info "Leaving UFW state as-is (pass --reset-firewall to reset and disable)"
+fi
+
+# ---------- Step 7: optional purge of installed security packages ----------
+if [ "$PURGE_PACKAGES" -eq 1 ]; then
+    HARDN_STATUS info "Purging HARDN-installed security packages"
+    SECURITY_PACKAGES=(
+        aide apparmor-profiles auditd clamav clamav-daemon
+        fail2ban firejail grafana suricata
+        ossec-hids wazuh-agent
+    )
+    export DEBIAN_FRONTEND=noninteractive
+    for pkg in "${SECURITY_PACKAGES[@]}"; do
+        if dpkg -s "$pkg" >/dev/null 2>&1; then
+            run_cmd "apt-get -y --purge remove '$pkg' >/dev/null 2>&1 || true"
+        fi
+    done
+    run_cmd "apt-get -y autoremove --purge >/dev/null 2>&1 || true"
+fi
+
+# ---------- Step 8: remove the .deb (if installed) ----------
+if dpkg -s hardn >/dev/null 2>&1; then
+    HARDN_STATUS info "Purging the hardn package"
+    run_cmd "DEBIAN_FRONTEND=noninteractive apt-get -y --purge remove hardn >/dev/null 2>&1 || dpkg -P hardn"
+fi
+
+# ---------- Step 9: remove runtime data ----------
+HARDN_STATUS info "Removing HARDN runtime data directories"
+# /etc/hardn — keep authorized_keys if requested, drop everything else
+if [ "$KEEP_KEYS" -eq 1 ] && [ -f /etc/hardn/authorized_keys ]; then
+    HARDN_STATUS info "Preserving /etc/hardn/authorized_keys"
+    run_cmd "find /etc/hardn -mindepth 1 -not -name authorized_keys -delete 2>/dev/null || true"
+else
+    run_cmd "rm -rf /etc/hardn"
+fi
+
+if [ "$KEEP_DATA" -ne 1 ]; then
+    # functions.sh' HARDN_STATUS appends to /var/log/hardn/hardn-tools.log on
+    # every call and re-creates the parent dir. Redirect future logging to
+    # /dev/null so the recovery-summary HARDN_STATUS calls below don't undo
+    # the cleanup we're about to do.
+    export HARDN_LOG_FILE=/dev/null
+    run_cmd "rm -rf /var/log/hardn /var/lib/hardn"
+else
+    HARDN_STATUS info "Preserving /var/log/hardn and /var/lib/hardn (--keep-data)"
+fi
+
+# Remove the installed payload tree if dpkg -P left anything behind
+run_cmd "rm -rf /usr/share/hardn /usr/lib/hardn 2>/dev/null || true"
+
+# ---------- Step 10: drop hardn user and group ----------
+if getent passwd hardn >/dev/null 2>&1; then
+    HARDN_STATUS info "Removing hardn system user"
+    run_cmd "deluser --quiet hardn >/dev/null 2>&1 || true"
+fi
+if getent group hardn >/dev/null 2>&1; then
+    HARDN_STATUS info "Removing hardn system group"
+    run_cmd "delgroup --quiet --only-if-empty hardn >/dev/null 2>&1 || true"
+fi
+
+# ---------- Step 11: print manual-recovery summary ----------
+cat <<'EOM'
+
+═══════════════════════════════════════════════════════════════════
+                  HARDN UNINSTALL COMPLETE
+═══════════════════════════════════════════════════════════════════
+
+Items that may need manual attention:
+
+  1. auditd rules: if HARDN's audit ruleset was loaded with '-e 2'
+     (immutable), the running kernel still has those rules until
+     the next reboot. A reboot finishes the audit revert.
+
+  2. /etc/login.defs and /etc/default/useradd: HARDN's hardening.sh
+     overwrote PASS_MAX_DAYS, PASS_MIN_DAYS, PASS_WARN_AGE, UMASK,
+     UID_MIN, ENCRYPT_METHOD, INACTIVE. These are not reverted by
+     this script because the original values weren't snapshotted.
+     Inspect those files and restore your site defaults if needed.
+
+  3. /etc/ssh/sshd_config: HARDN may have created a timestamped
+     backup at /etc/ssh/sshd_config.bak.YYYYMMDD. Restore it
+     manually if the active config has unwanted settings.
+
+  4. /etc/modprobe.d/blacklist-firewire.conf: if HARDN added this
+     and you want firewire back, remove the file and run
+     'sudo update-initramfs -u'.
+
+  5. UFW persistent rules: if --reset-firewall was NOT passed,
+     HARDN's strict UFW policy is still active and persists across
+     reboot. Run 'sudo ufw reset && sudo ufw disable' to remove.
+
+  6. SELinux: if 'hardn --enable-selinux' was run on this host,
+     undo it by:
+       - removing 'security=selinux selinux=1' from /etc/default/grub
+       - 'sudo update-grub'
+       - 'sudo apt install apparmor apparmor-profiles apparmor-utils'
+       - 'sudo apt remove selinux-basics selinux-policy-default'
+       - 'sudo rm -f /.autorelabel'
+       - reboot
+
+EOM
+
+HARDN_STATUS pass "Uninstall complete."
+exit 0


### PR DESCRIPTION
## Summary

Three commits — LEGION→alert wire-up, the final 15 audit rules to reach 100% coverage, and the operational safety set (uninstall script + boot-time guards).

### LEGION → alerts (`8c4e92f`)

- `src/utils/alerts.rs`: new shared module factored out of `hardn-monitor.rs`. `emit_alert(severity, source, message, key)` appends a single JSON-lines record to `/var/log/hardn/alerts.jsonl`. `emit_alert_to(path, …)` for tests. `build_alert_payload` is the pure-formatting helper unit-tested without touching disk.
- `src/legion/core/legion.rs`: two emit points in the LEGION monitoring loop:
  - Risk level High → `error`, Critical → `critical`, keyed by level so a sustained risky state surfaces as one updating row.
  - Response-enabled and `overall_score > 0.7` → `warning` before `execute_automated_response` runs.
- `hardn-monitor.rs` now pulls the shared module in via `#[path = "utils/alerts.rs"]` (no `[lib]` target).

### 100% audit coverage (`4f775b7`)

194/194 rules implemented. The final 15:

- Loopback firewall rules (iptables, ip6tables, ufw, nftables)
- nftables structural (`set_nftables_table`, `set_nftables_base_chain`, `nftables_rules_permanent`)
- Listening ports cross-checked against firewall rules — parses `ss -lntH` for listening TCP, confirms each port has a matching `dport <port>` / `--dport <port>` rule in `iptables -S` / `ufw status`
- Filesystem walks via `nftw(FTW_PHYS|FTW_MOUNT|FTW_ACTIONRETVAL)`:
  - `file_permissions_unauthorized_world_writable`
  - `no_files_unowned_by_user`
  - `file_permissions_ungroupowned`

  Skips `/proc /sys /dev /run /snap /var/lib/{docker,containers,lxd,lxc}`, never crosses mounts, never follows symlinks, caps at 250 000 inodes
- PATH directory writability: `accounts_root_path_dirs_no_write` + `accounts_user_dot_no_world_writable_programs`

Adds `<ftw.h>` and `_GNU_SOURCE` for `FTW_ACTIONRETVAL`.

### Uninstall + boot safety (`5e471fa`)

**Uninstall:**

| Surface | Where |
|---|---|
| Headless script | `usr/share/hardn/scripts/hardn-uninstall.sh` |
| CLI flag | `hardn --uninstall [--yes ...]` (in `src/main.rs`) |
| GUI menu | new entry 2 in `dangerous_operations_menu` (in `hardn-service-manager.sh`) with `YES UNINSTALL` confirmation and y/N prompts for each opt-in flag |

The script stops + disables HARDN services, removes every `99-hardn-*.conf` drop-in we wrote across `/etc`, removes HARDN-added APT repos + keyrings, runs `dpkg -P hardn`, drops the `hardn` user/group, removes `/var/log/hardn` + `/var/lib/hardn` + `/etc/hardn`. Flags `--yes`, `--dry-run`, `--keep-data`, `--keep-keys`, `--restore-ssh`, `--reset-firewall`, `--purge-packages` are all opt-in. Prints a manual-recovery summary at the end covering things that can't be reverted from userspace (auditd `-e 2` until reboot, `/etc/login.defs` edits not snapshotted, modprobe firewire blacklist + initramfs rebuild, UFW persistent rules, SELinux undo).

Verified end-to-end: install .deb → `hardn --uninstall --yes` → `id hardn` reports "no such user", all dirs gone.

**Boot safety (the issues from the boot-risk assessment):**

1. `systemd/hardn-api.service` — new `ExecStartPre` refuses to start when `/etc/hardn/authorized_keys` is missing or empty. Closes the gap where the API listens on `0.0.0.0:8000` with zero registered keys.

2. `hardn.service` ↔ `legion-daemon.service` overlap resolved:
   - Mutual `Conflicts=` directives in both unit files
   - `debian/postinst` no longer enables `legion-daemon.service`
   - Migration on upgrade: postinst disables any existing enabled `legion-daemon.service` instance
   - Operators who want the response-disabled variant swap: `systemctl disable hardn.service; systemctl enable --now legion-daemon.service`

3. `hardn.service` ExecStart no longer hardcodes `--response-enabled`. Default is observe-only. Operators opt in via `/etc/hardn/legion.env`:

   ```
   HARDN_LEGION_EXTRA_ARGS="--response-enabled"
   ```

   Prevents auto-response actions from firing on every boot.

## Test plan

- [ ] CI build job — includes a fresh-container install/uninstall smoke
- [ ] `hardn --uninstall --yes --dry-run` exits 0 with a printed action list
- [ ] `hardn --uninstall --yes` from a real install removes user, /etc/hardn, /var/log/hardn, package, leaves firewall + ssh alone (no flags)
- [ ] `hardn-api.service` refuses to start when authorized_keys is empty/missing
- [ ] On upgrade from a prior version, `legion-daemon.service` is auto-disabled
- [ ] `hardn.service` no longer passes `--response-enabled` unless `/etc/hardn/legion.env` says so

## Notes for review

- The shared `src/utils/alerts.rs` module is imported by `hardn-monitor.rs` via `#[path]` because neither binary has a `[lib]` target. If a `[lib]` is added later, switch to `crate::utils::alerts`.
- The uninstall script's recovery summary is intentionally verbose. Customer support will want to point operators at it.
- The filesystem walks in `hardn-audit` can take up to 10 s on a 4-core box — acceptable for an on-demand audit, not for any boot-path or hot loop.
- Tests: 19/19 pass (was 7 at the start of this overall work).