### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# HARDN code owners.
+#
+# Lines later in this file take precedence over earlier ones. The default
+# pattern below means @OpenSource-For-Freedom is requested as a reviewer
+# for any change that doesn't match a more specific pattern below.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @OpenSource-For-Freedom


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` with `@OpenSource-For-Freedom` as the global owner so every PR automatically requests review from you.

```
*       @OpenSource-For-Freedom
```

Once merged, GitHub will:
- Auto-request your review on every new PR
- (If branch protection is configured to require code-owner review on main) block merges until the owner approves

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, opening a fresh PR triggers an automatic review request to @OpenSource-For-Freedom

## Notes

- Per-path owners (e.g. extra reviewers required for `debian/`, `systemd/`, `src/audit/`, `src/legion/`) can be added later as the team grows.
- File lives in `.github/CODEOWNERS`; GitHub also accepts root or `docs/` location.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_