### PR TITLE
Improve Discord release notification (tag + changelog + real URL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,13 +427,37 @@ jobs:
           STATUS="${{ job.status }}"
           VERSION="${{ steps.version.outputs.version }}"
           DEB_NAME="${{ steps.version.outputs.deb_name }}"
-          MSG="https://github.com/${{ github.repository }}/releases/tag/latest"
-          IMG_URL="/docs/assets/IMG_1233.jpeg"
+          PREV_TAG="${{ steps.tag.outputs.latest_tag }}"
+          NEW_TAG="${{ steps.tag.outputs.new_tag }}"
+          REPO="${{ github.repository }}"
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/${NEW_TAG}"
+          COMPARE_URL="https://github.com/${REPO}/compare/${PREV_TAG}...${NEW_TAG}"
+
           COLOR=15105570
           [[ "$STATUS" == "success" ]] && COLOR=3066993 || true
           [[ "$STATUS" == "failure" ]] && COLOR=15158332 || true
 
-          DESCRIPTION="Status: ${STATUS} on ${DEB_NAME} (v${VERSION})"
+          # Build short changelog from commits since previous tag (max 10 lines).
+          # Skip merge commits; trim each subject to 100 chars to keep the embed tidy.
+          CHANGES=""
+          if [[ -n "$PREV_TAG" ]] && git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            CHANGES=$(git log "${PREV_TAG}..HEAD" --no-merges --pretty=format:'%s' \
+              | head -n 10 \
+              | awk '{ if (length($0) > 100) print "- " substr($0,1,97) "..."; else print "- " $0 }')
+          fi
+          [[ -z "$CHANGES" ]] && CHANGES="- (no commits since ${PREV_TAG:-previous release})"
+
+          TITLE="HARDN Release ${NEW_TAG}"
+          DESCRIPTION=$(printf 'Status: **%s** — `%s`\n\n**Changes since %s:**\n%s\n\n[Full changelog](%s)' \
+            "$STATUS" "$DEB_NAME" "${PREV_TAG:-initial}" "$CHANGES" "$COMPARE_URL")
+
+          # Build payload with jq so commit subjects are escaped safely.
+          PAYLOAD=$(jq -n \
+            --arg title "$TITLE" \
+            --arg description "$DESCRIPTION" \
+            --arg url "$RELEASE_URL" \
+            --argjson color "$COLOR" \
+            '{embeds:[{title:$title, description:$description, color:$color, url:$url}]}')
 
           curl -H "Content-Type: application/json" -X POST "$WEBHOOK" \
-            -d "{\"embeds\":[{\"title\":\"HARDN Release\",\"description\":\"$DESCRIPTION\",\"color\":$COLOR,\"url\":\"$MSG\"}]}" || true
+            -d "$PAYLOAD" || true


### PR DESCRIPTION
## Summary

The Discord `HARDN Release` notification currently posts the same line every release:

```
Status: success on hardn_1.0.0-1_amd64.deb (v1.0.0-1)
```

and links to `/releases/tag/latest` (which 404s). This PR fixes the `Discord notification` step in `.github/workflows/ci.yml` so each release post actually describes the release.

### After this PR, each notification will show:

- **Title**: `HARDN Release v1.0.2-1` ← the actual new tag
- **Description**:
  ```
  Status: success — `hardn_1.0.2-1_amd64.deb`

  Changes since v1.0.1-1:
  - PATCH: add CODEOWNERS with @OpenSource-For-Freedom as global owner
  - PATCH: full uninstall + boot-safety fixes for hardn-api / hardn.service / legion-daemon.service
  - PATCH: implement the final 15 audit checks — 100% coverage (194/194 rules)
  - PATCH: LEGION emits alerts to the shared alert channel on high/critical risk
  ...
  [Full changelog](https://github.com/.../compare/v1.0.1-1...v1.0.2-1)
  ```
- **URL**: `https://github.com/.../releases/tag/v1.0.2-1` (real release page, not `tag/latest`)
- **Colour**: green/red/orange for success/failure/other (unchanged)

### Implementation notes

- Changelog: `git log $PREV_TAG..HEAD --no-merges`, max 10 entries, subjects trimmed to 100 chars. Falls back to `- (no commits since previous release)` if the previous tag can't be resolved.
- Payload built with `jq` so commit subjects containing `"` or `\` can't break the JSON (the old `printf` template would have).
- `fetch-depth: 0` is already set on the release-job checkout, so `git log PREV..HEAD` resolves.

## Test plan

- [ ] CI passes on this PR.
- [ ] Next release to `main` posts a Discord embed titled `HARDN Release v<new tag>` with a bulleted changelog.
- [ ] Clicking the embed title opens the real release page (not a 404).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_