### PR TITLE
Cut debian/changelog 1.1.0-1 with all changes since 1.0.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,53 @@
+hardn (1.1.0-1) bookworm; urgency=medium
+
+  [ Audit framework — 100% coverage (194/194 rules) ]
+  * Implement 25 sysctl-based audit checks for kernel network hardening
+  * Implement 19 mount-option audit checks via /proc/mounts
+  * Implement 19 audit checks for audit subsystem, GRUB, journald, rsyslog,
+    coredumps, wireless and wheel-group restrictions
+  * Implement 16 audit checks for shadow ages, PAM faillock, GRUB,
+    AppArmor and rsyslog network configuration
+  * Implement the final 15 audit checks — 100% coverage (194/194 rules)
+  * Implement 12 audit checks for account structure, password ages, umask
+  * Implement 9 systemd service-state audit checks via systemctl
+  * Implement 8 dpkg-based package install-state audit checks
+  * Implement 8 audit checks for home directory and dotfile hygiene
+  * Implement firewall default-policy and /var/log permissions audit checks
+  * Implement audit checks for passwd/shadow/cron file owner, group and mode
+  * Implement 2 kernel-module-disabled audit checks (cramfs, usb-storage)
+
+  [ LEGION and alerting ]
+  * LEGION emits alerts to the shared alert channel on high/critical risk
+  * Structured alert channel from hardn-monitor to hardn-gui
+  * Unify LEGION baseline DB path via Config::database_path()
+
+  [ hardn-gui ]
+  * Tail all HARDN log files and follow correctly from the left pane
+  * Clean security report warning output
+  * Inline CSS path validation; remove deleted path_security dependency
+  * Fix GTK app output error (ISSUE_135)
+
+  [ Packaging and installation ]
+  * Full uninstall script with boot-safety fixes for hardn-api,
+    hardn.service and legion-daemon.service
+  * Harden tool-launch safety — rename selinux.sh to selinux.sh.DANGEROUS,
+    filter helper libraries, fix install logic
+  * Ignore dpkg-buildpackage hardn.debhelper.log artifact
+  * Fix dpkg failure for monitor output
+  * Fix version mismatch in hardn-monitor (ISSUE_134)
+  * Fix staircasing output issue
+
+  [ CI and release ]
+  * Richer Discord release notification — embeds the new tag, a short
+    changelog of commits since the previous release, and a working URL
+    to the actual release page
+  * Add .github/CODEOWNERS with @OpenSource-For-Freedom as global owner
+  * Run ci.yml on pull requests to main; gate release job to main pushes
+  * Apply least-privilege permissions per job in CI
+  * Various GitHub Actions and Rust dependency bumps via Dependabot
+
+ -- Security International Group <contact@sig.com>  Sun, 24 May 2026 19:30:00 +0000
+
 hardn (1.0.0-1) bookworm; urgency=medium
 
   * Initial public demo release


### PR DESCRIPTION
## Summary

`debian/changelog` had not been updated since the **1.0.0-1** initial release in September 2024, so every `.deb` built by CI since then has shipped under the same filename (`hardn_1.0.0-1_amd64.deb`) — which is the line everyone keeps seeing in the Discord `#inbound` channel.

This PR cuts a new **`1.1.0-1`** entry that captures all the cumulative work since 1.0.0-1, grouped into:

- **Audit framework** reaching 100% coverage (194/194 rules) — sysctl, mounts, audit subsystem, GRUB, journald, rsyslog, coredumps, AppArmor, faillock, account/password hygiene, dpkg state, systemd units, kernel-module-disabled checks, firewall + `/var/log` perms.
- **LEGION and alerting** — shared alert channel from monitor to GUI, baseline DB path unification.
- **hardn-gui** — log tailing across all HARDN logs, CSS path validation, GTK output fix (ISSUE_135).
- **Packaging and installation** — full uninstall script + boot-safety fixes for `hardn-api` / `hardn.service` / `legion-daemon.service`, tool-launch hardening (`selinux.sh` → `selinux.sh.DANGEROUS`), `dpkg-buildpackage` artifact ignore, monitor version fix (ISSUE_134).
- **CI and release** — Discord notification rewrite (real tag + short changelog + working URL), `CODEOWNERS`, PR-trigger gating, least-privilege CI permissions, dep bumps.

Validated locally with `dpkg-parsechangelog -l debian/changelog --show-field Version` → `1.1.0-1`.

## Test plan

- [ ] CI passes on this PR.
- [ ] Next release run produces `hardn_1.1.0-1_amd64.deb` (not `1.0.0-1`).
- [ ] Discord post titled `HARDN Release v<new tag>` shows the new `.deb` name and the commit-based changelog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_