### PR TITLE
Add CHANGELOG.md and use it for GitHub release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,29 +374,40 @@ jobs:
 
           SIZE=$(du -h "$DEB_FILE" | cut -f1)
           SHA256=$(sha256sum "$DEB_FILE" | awk '{print $1}')
-          BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC)')
+          BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           COMMIT_SHA="${{ github.sha }}"
-          DOCS_URL="https://github.com/${{ github.repository }}/tree/main/docs"
 
-          cat > RELEASE_NOTES.md <<EOF
-          ![HARDN](docs/assets/IMG_1233.jpeg)
+          # Extract the latest section from CHANGELOG.md (everything from
+          # the first "## [" header to the next one, exclusive). Falls back
+          # to a short notice if CHANGELOG.md is missing or unparseable.
+          if [ -f CHANGELOG.md ]; then
+            CHANGELOG_SECTION=$(awk '/^## \[/{if (n++) exit} n' CHANGELOG.md)
+          fi
+          if [ -z "${CHANGELOG_SECTION:-}" ]; then
+            CHANGELOG_SECTION="_See \`CHANGELOG.md\` in the repository for release notes._"
+          fi
 
-          # HARDN $TAG
-
-          > Automated release generated on $BUILD_DATE from commit $COMMIT_SHA.
-
-          ## Package Details
-                - **Debian package**: \`$DEB_NAME\`
-                - **Project version**: \`$VERSION\`
-                - **Architecture**: \`$ARCH\`
-                - **Size**: \`$SIZE\`
-                - **SHA256**: \`$SHA256\`
-
-
-          ---
-
-          Built with dpkg-buildpackage • Validated by integration tests
-          EOF
+          {
+            echo "![HARDN](docs/assets/IMG_1233.jpeg)"
+            echo
+            echo "# HARDN $TAG"
+            echo
+            echo "> Automated release generated on $BUILD_DATE from commit $COMMIT_SHA."
+            echo
+            echo "$CHANGELOG_SECTION"
+            echo
+            echo "## Package Details"
+            echo
+            echo "- **Debian package**: \`$DEB_NAME\`"
+            echo "- **Project version**: \`$VERSION\`"
+            echo "- **Architecture**: \`$ARCH\`"
+            echo "- **Size**: \`$SIZE\`"
+            echo "- **SHA256**: \`$SHA256\`"
+            echo
+            echo "---"
+            echo
+            echo "Built with dpkg-buildpackage • Validated by integration tests"
+          } > RELEASE_NOTES.md
         shell: bash
 
       - name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to **HARDN** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0-1] - 2026-05-24
+
+### Audit framework — 100% coverage (194/194 rules)
+
+- 25 sysctl-based audit checks for kernel network hardening
+- 19 mount-option audit checks via `/proc/mounts`
+- 19 audit checks for the audit subsystem, GRUB, journald, rsyslog,
+  coredumps, wireless and wheel-group restrictions
+- 16 audit checks for shadow ages, PAM faillock, GRUB, AppArmor and
+  rsyslog network configuration
+- 15 final audit checks to reach 100% rule coverage
+- 12 audit checks for account structure, password ages and umask
+- 9 systemd service-state audit checks via `systemctl`
+- 8 dpkg-based package install-state audit checks
+- 8 audit checks for home directory and dotfile hygiene
+- Firewall default-policy and `/var/log` permissions audit checks
+- Audit checks for `passwd`, `shadow` and cron file owner, group and mode
+- 2 kernel-module-disabled audit checks (`cramfs`, `usb-storage`)
+
+### LEGION and alerting
+
+- LEGION emits alerts to the shared alert channel on high/critical risk
+- Structured alert channel from `hardn-monitor` to `hardn-gui`
+- Unified LEGION baseline DB path via `Config::database_path()`
+
+### hardn-gui
+
+- Tails all HARDN log files and follows correctly from the left pane
+- Cleaned security report warning output
+- Inline CSS path validation; removed deleted `path_security` dependency
+- Fixed GTK app output error (ISSUE_135)
+
+### Packaging and installation
+
+- Full uninstall script with boot-safety fixes for `hardn-api`,
+  `hardn.service` and `legion-daemon.service`
+- Hardened tool-launch safety — renamed `selinux.sh` to
+  `selinux.sh.DANGEROUS`, filter helper libraries, fix install logic
+- Ignored `dpkg-buildpackage` `hardn.debhelper.log` artifact
+- Fixed dpkg failure for monitor output
+- Fixed version mismatch in `hardn-monitor` (ISSUE_134)
+- Fixed staircasing output issue
+
+### CI and release
+
+- Richer Discord release notification — embeds the new tag, a short
+  changelog of commits since the previous release, and a working URL
+  to the actual release page
+- Added `.github/CODEOWNERS` with `@OpenSource-For-Freedom` as global owner
+- Run `ci.yml` on pull requests to `main`; gate the release job to
+  `main` pushes
+- Applied least-privilege permissions per job in CI
+- Various GitHub Actions and Rust dependency bumps via Dependabot
+
+## [1.0.0-1] - 2024-09-21
+
+### Added
+
+- Initial public demo release
+- Core security hardening framework
+- Modular architecture with tools support
+- Included tools: AIDE, Legion, Fail2ban
+- Rust-based CLI interface
+- Debian packaging support
+- Basic system hardening capabilities


### PR DESCRIPTION
## Summary

Adds a top-level **`CHANGELOG.md`** (Keep-a-Changelog style) and wires the CI release-notes generator to embed its latest section into each GitHub release. After this lands, `CHANGELOG.md` is the single source of truth for human-readable release content; the GitHub release page will show the same bullets that appear in the repo.

### `CHANGELOG.md` (new)

Mirrors the `debian/changelog` 1.1.0-1 entry, organised by area (audit framework, LEGION/alerting, hardn-gui, packaging, CI/release). 1.0.0-1 is included as the prior entry. No AI/assistant attribution anywhere.

### `.github/workflows/ci.yml` — `Generate release notes`

- Extracts the latest section from `CHANGELOG.md` with
  `awk '/^## \[/{if (n++) exit} n'` — everything from the first
  `## [X.Y.Z]` header up to (but not including) the next one.
- Drops the broken leading-whitespace heredoc that was indenting the
  package-details bullets so far that GitHub rendered them as a code block.
- Also fixes a stray `)` in the `BUILD_DATE` format string.
- Falls back to `_See CHANGELOG.md in the repository for release notes._`
  if `CHANGELOG.md` is missing or unparseable, so the release never fails
  on a notes-formatting issue.

### Three changelog surfaces, all consistent

| Surface | Source | Frequency |
|---|---|---|
| `debian/changelog` | Hand-maintained, Debian format | Per `.deb` version bump |
| `CHANGELOG.md` | Hand-maintained, Keep-a-Changelog | Per release |
| GitHub Release notes | **Auto-generated from `CHANGELOG.md`** | Every release run |
| Discord post | Auto-generated from `git log` | Every release run |

## Test plan

- [ ] CI passes on this PR.
- [ ] Next release on `main` produces a GitHub release whose body starts with the `## [1.1.0-1]` section from `CHANGELOG.md` and ends with package details + SHA256.
- [ ] No "claude" / "anthropic" / "copilot" strings anywhere in the rendered release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_