### PR TITLE
LEGION sentry: baseline-diff alerts + journald/webhook sinks (PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### LEGION tattletale (phase 1)
+
+- New **sentry** module (`legion::modules::sentry`) — runs once-per-day from
+  the cron orchestrator, sha256-hashes a curated set of high-value files,
+  diffs them against `/var/lib/hardn/sentry/baseline.json`, and emits one
+  alert per added / removed / changed entry. Watched paths:
+  `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, `/etc/group`,
+  `/etc/sudoers`, `/etc/sudoers.d/*`, `/{root,/home/*}/.ssh/authorized_keys{,2}`,
+  `/etc/crontab`, `/etc/cron.{d,daily,hourly,weekly,monthly}/*`,
+  `/var/spool/cron/{,crontabs/}*`,
+  `/etc/systemd/system/*.{service,timer,socket,path}`,
+  `/etc/systemd/system/*.d/*.conf`
+- New CLI: `hardn --sentry-check` — runs sentry once, prints a short report,
+  emits alerts. First run silently writes the baseline; subsequent runs alert
+  on drift. Authorized-keys / sudoers drift → `critical`; cron / systemd /
+  passwd-shadow drift → `warning`.
+- New cron job `hardn-sentry` runs daily at 02:15.
+- Alerts now also fan out to **journald** (always) and **webhook**
+  (when `$HARDN_ALERT_WEBHOOK_URL` is set). Both sinks share a TTL-based
+  dedupe cache at `/var/lib/hardn/alerts/seen.json` so a noisy condition
+  can't pager-spam an on-call.
+  - Journald uses `systemd-cat -t HARDN-ALERT -p <prio>` (fallback `logger`
+    on non-systemd hosts). Tag overridable via `$HARDN_ALERT_JOURNALD_TAG`.
+  - Webhook POSTs the same JSON payload as `alerts.jsonl` (`ts`, `severity`,
+    `source`, `message`, `key`) via `curl -fsS -m 10`. http:// and https://
+    only. No new compile-time dep added.
+  - Dedupe TTL defaults to 6 hours; override via `$HARDN_ALERT_DEDUPE_TTL_SEC`.
+
 ### Tools hygiene
 
 - Cron orchestrator now wraps every job in `/usr/bin/flock -n -E 99` keyed

--- a/src/core/cron.rs
+++ b/src/core/cron.rs
@@ -580,6 +580,19 @@ impl CronOrchestrator {
                 "/usr/bin/hardn",
                 &["legion", "--create-baseline", "--json"],
             ))),
+            // Sentry: daily diff of high-value files (cron / systemd /
+            // authorized_keys / sudoers / passwd-shadow). Runs at 02:15 daily
+            // so it sits in the quiet window after the legion baseline and
+            // before the Sunday weekly batch.
+            Arc::new(ScheduledJob::new(CronJob::daily_job(
+                "hardn-sentry",
+                "Diff high-value files against persisted baseline",
+                &log_root,
+                "hardn-sentry.log",
+                DailyTime { hour: 2, minute: 15 },
+                "/usr/bin/hardn",
+                &["--sentry-check"],
+            ))),
         ];
 
         {

--- a/src/legion/modules/mod.rs
+++ b/src/legion/modules/mod.rs
@@ -14,6 +14,7 @@ pub mod permissions;
 pub mod processes;
 pub mod response;
 pub mod risk_scoring;
+pub mod sentry;
 pub mod services;
 pub mod threat_intel;
 pub mod usb;

--- a/src/legion/modules/sentry/mod.rs
+++ b/src/legion/modules/sentry/mod.rs
@@ -1,0 +1,429 @@
+//! Sentry: high-value file drift detector ("tattletale phase 1").
+//!
+//! Watches a small, hand-picked list of files that an attacker would have to
+//! touch to establish persistence on a typical Linux host:
+//!
+//! * `/etc/passwd`, `/etc/shadow`   — new accounts, locked-account changes
+//! * `/etc/sudoers`, `/etc/sudoers.d/*` — privilege grants
+//! * `/root/.ssh/authorized_keys`, `/home/*/.ssh/authorized_keys` — SSH backdoor
+//! * `/etc/cron.{d,daily,hourly,weekly,monthly}/*`, `/var/spool/cron/*`
+//!     — scheduled task persistence
+//! * `/etc/systemd/system/*.{service,timer}`,
+//!   `/etc/systemd/system/*.{service,timer}.d/*.conf` — service persistence
+//!
+//! On the first run we just persist a baseline of sha256(path) → digest into
+//! `/var/lib/hardn/sentry/baseline.json`. On every subsequent run we recompute
+//! and diff against the baseline; any added/removed/changed entry produces an
+//! `emit_alert(...)` call so it lands in `alerts.jsonl` AND fans out to the
+//! journald + webhook sinks (with dedupe — see `crate::utils::alerts`).
+//!
+//! Public entry point: [`run_check`]. Designed to be invoked once-per-run by
+//! the cron orchestrator (`hardn --sentry-check`) so it stays decoupled from
+//! the LEGION long-running daemon — failure to run it can never crash legion,
+//! and the user can `hardn --sentry-check` on demand to baseline before/after
+//! changes.
+
+use crate::utils::emit_alert;
+use chrono::Utc;
+use glob::glob;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+/// Where the persisted baseline lives. Overridden in tests via [`SentryConfig`].
+pub const DEFAULT_BASELINE_PATH: &str = "/var/lib/hardn/sentry/baseline.json";
+
+/// Categories used to assign severity and the alert "source" string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    AuthorizedKeys,
+    Sudoers,
+    PasswdShadow,
+    Cron,
+    Systemd,
+}
+
+impl Category {
+    pub fn label(self) -> &'static str {
+        match self {
+            Category::AuthorizedKeys => "authorized_keys",
+            Category::Sudoers => "sudoers",
+            Category::PasswdShadow => "passwd_shadow",
+            Category::Cron => "cron",
+            Category::Systemd => "systemd",
+        }
+    }
+}
+
+/// One watched location: either an exact path or a glob pattern.
+#[derive(Debug, Clone)]
+pub struct WatchSpec {
+    pub category: Category,
+    pub patterns: Vec<&'static str>,
+}
+
+/// Built-in watch set. Phase 1 is deliberately small — every entry here has a
+/// high signal-to-noise ratio. Wider coverage is a follow-up phase.
+pub fn default_watches() -> Vec<WatchSpec> {
+    vec![
+        WatchSpec {
+            category: Category::PasswdShadow,
+            patterns: vec!["/etc/passwd", "/etc/shadow", "/etc/gshadow", "/etc/group"],
+        },
+        WatchSpec {
+            category: Category::Sudoers,
+            patterns: vec!["/etc/sudoers", "/etc/sudoers.d/*"],
+        },
+        WatchSpec {
+            category: Category::AuthorizedKeys,
+            patterns: vec![
+                "/root/.ssh/authorized_keys",
+                "/root/.ssh/authorized_keys2",
+                "/home/*/.ssh/authorized_keys",
+                "/home/*/.ssh/authorized_keys2",
+            ],
+        },
+        WatchSpec {
+            category: Category::Cron,
+            patterns: vec![
+                "/etc/crontab",
+                "/etc/cron.d/*",
+                "/etc/cron.hourly/*",
+                "/etc/cron.daily/*",
+                "/etc/cron.weekly/*",
+                "/etc/cron.monthly/*",
+                "/var/spool/cron/*",
+                "/var/spool/cron/crontabs/*",
+            ],
+        },
+        WatchSpec {
+            category: Category::Systemd,
+            patterns: vec![
+                "/etc/systemd/system/*.service",
+                "/etc/systemd/system/*.timer",
+                "/etc/systemd/system/*.socket",
+                "/etc/systemd/system/*.path",
+                "/etc/systemd/system/*.d/*.conf",
+            ],
+        },
+    ]
+}
+
+/// Optional override knobs for tests. Production uses [`default()`].
+#[derive(Debug, Clone)]
+pub struct SentryConfig {
+    pub baseline_path: PathBuf,
+    pub watches: Vec<WatchSpec>,
+}
+
+impl Default for SentryConfig {
+    fn default() -> Self {
+        Self {
+            baseline_path: PathBuf::from(DEFAULT_BASELINE_PATH),
+            watches: default_watches(),
+        }
+    }
+}
+
+/// On-disk shape of the baseline. Keys are absolute paths; values are
+/// `(category_label, sha256_hex)` — the label is stored so a future
+/// refactor that drops or renames a category can still surface stale
+/// entries on the next run.
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct Baseline {
+    pub created_at: String,
+    pub entries: BTreeMap<String, BaselineEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct BaselineEntry {
+    pub category: String,
+    pub sha256: String,
+}
+
+/// Summary returned by [`run_check`] so the CLI can print something useful.
+#[derive(Debug, Default, Serialize, Clone, PartialEq, Eq)]
+pub struct SentryReport {
+    pub first_run: bool,
+    pub watched_files: usize,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub changed: Vec<String>,
+}
+
+impl SentryReport {
+    pub fn total_changes(&self) -> usize {
+        self.added.len() + self.removed.len() + self.changed.len()
+    }
+}
+
+/// Hash a file's contents. Returns None on read errors (permission denied,
+/// dangling symlink, etc.) — the caller treats "unreadable" as "absent" which
+/// is the right behaviour for a sentry: an attacker who chmod 000's a watched
+/// file deserves a "removed" alert.
+fn sha256_of(path: &Path) -> Option<String> {
+    let mut f = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match f.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => hasher.update(&buf[..n]),
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => return None,
+        }
+    }
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+/// Expand the watch patterns against the filesystem, returning a flat
+/// `path -> (category, sha256)` map.
+pub fn snapshot(watches: &[WatchSpec]) -> BTreeMap<String, BaselineEntry> {
+    let mut out = BTreeMap::new();
+    for spec in watches {
+        for pat in &spec.patterns {
+            let iter = match glob(pat) {
+                Ok(it) => it,
+                Err(_) => continue,
+            };
+            for entry in iter.flatten() {
+                if entry.is_file() {
+                    if let Some(hex) = sha256_of(&entry) {
+                        out.insert(
+                            entry.display().to_string(),
+                            BaselineEntry {
+                                category: spec.category.label().to_string(),
+                                sha256: hex,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn load_baseline(path: &Path) -> Option<Baseline> {
+    let s = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+fn save_baseline(path: &Path, baseline: &Baseline) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    let s = serde_json::to_string_pretty(baseline)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    fs::write(&tmp, s)?;
+    fs::rename(&tmp, path)
+}
+
+/// Diff current snapshot against baseline; produce the (added, removed, changed) tuple.
+pub fn diff(
+    baseline: &BTreeMap<String, BaselineEntry>,
+    current: &BTreeMap<String, BaselineEntry>,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut changed = Vec::new();
+    for (path, entry) in current {
+        match baseline.get(path) {
+            None => added.push(path.clone()),
+            Some(prev) if prev.sha256 != entry.sha256 => changed.push(path.clone()),
+            _ => {}
+        }
+    }
+    for path in baseline.keys() {
+        if !current.contains_key(path) {
+            removed.push(path.clone());
+        }
+    }
+    (added, removed, changed)
+}
+
+/// Run one sentry pass. On first run, writes baseline and reports
+/// `first_run=true`. On subsequent runs, diffs against baseline, fires an
+/// alert per changed entry, and refreshes the baseline.
+pub fn run_check() -> SentryReport {
+    run_with_config(&SentryConfig::default(), |sev, src, msg, key| {
+        emit_alert(sev, src, msg, key);
+    })
+}
+
+/// Test seam: same logic, but the alert callback and config are injectable.
+pub fn run_with_config<F>(cfg: &SentryConfig, mut alert: F) -> SentryReport
+where
+    F: FnMut(&str, &str, &str, &str),
+{
+    let current = snapshot(&cfg.watches);
+    let mut report = SentryReport {
+        watched_files: current.len(),
+        ..SentryReport::default()
+    };
+
+    let new_baseline = Baseline {
+        created_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        entries: current.clone(),
+    };
+
+    match load_baseline(&cfg.baseline_path) {
+        None => {
+            // First run — just persist the baseline.
+            report.first_run = true;
+            let _ = save_baseline(&cfg.baseline_path, &new_baseline);
+            return report;
+        }
+        Some(prev) => {
+            let (added, removed, changed) = diff(&prev.entries, &current);
+            report.added = added.clone();
+            report.removed = removed.clone();
+            report.changed = changed.clone();
+
+            for path in &added {
+                fire_alert(&mut alert, &current, path, "added");
+            }
+            for path in &changed {
+                fire_alert(&mut alert, &current, path, "changed");
+            }
+            for path in &removed {
+                fire_alert(&mut alert, &prev.entries, path, "removed");
+            }
+            let _ = save_baseline(&cfg.baseline_path, &new_baseline);
+        }
+    }
+
+    report
+}
+
+fn fire_alert<F>(
+    alert: &mut F,
+    entries: &BTreeMap<String, BaselineEntry>,
+    path: &str,
+    verb: &str,
+) where
+    F: FnMut(&str, &str, &str, &str),
+{
+    let category_label = entries
+        .get(path)
+        .map(|e| e.category.as_str())
+        .unwrap_or("unknown");
+    let severity = match category_label {
+        "authorized_keys" | "sudoers" => "critical",
+        _ => "warning",
+    };
+    let source = format!("sentry/{}", category_label);
+    let message = format!("{} {} watched file: {}", category_label, verb, path);
+    // Dedupe key: per-category + per-path + per-verb. A file that ping-pongs
+    // (added then removed then added) is treated as fresh news each cycle.
+    let key = format!("sentry:{}:{}:{}", category_label, verb, path);
+    alert(severity, &source, &message, &key);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn dummy_config(tmp: &Path) -> SentryConfig {
+        SentryConfig {
+            baseline_path: tmp.join("baseline.json"),
+            watches: vec![WatchSpec {
+                category: Category::Sudoers,
+                patterns: vec![],
+            }],
+        }
+    }
+
+    #[test]
+    fn first_run_writes_baseline_and_alerts_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dummy_config(dir.path());
+        let alerts: RefCell<Vec<String>> = RefCell::new(vec![]);
+        let report = run_with_config(&cfg, |sev, _, msg, _| {
+            alerts.borrow_mut().push(format!("{}: {}", sev, msg));
+        });
+        assert!(report.first_run);
+        assert_eq!(alerts.borrow().len(), 0);
+        assert!(cfg.baseline_path.exists());
+    }
+
+    #[test]
+    fn change_emits_alert_with_correct_severity() {
+        let dir = tempfile::tempdir().unwrap();
+        let sudoers = dir.path().join("sudoers");
+        fs::write(&sudoers, "alice ALL=(ALL) NOPASSWD: ALL\n").unwrap();
+
+        // Pre-populate baseline manually so the test doesn't depend on glob
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            sudoers.display().to_string(),
+            BaselineEntry {
+                category: "sudoers".into(),
+                sha256: sha256_of(&sudoers).unwrap(),
+            },
+        );
+        let baseline = Baseline {
+            created_at: "test".into(),
+            entries,
+        };
+        let baseline_path = dir.path().join("baseline.json");
+        save_baseline(&baseline_path, &baseline).unwrap();
+
+        // Mutate the file.
+        fs::write(&sudoers, "alice ALL=(ALL) NOPASSWD: ALL\nbob ALL=(ALL) NOPASSWD: ALL\n").unwrap();
+
+        // Run with a synthetic watch list pointing at the temp dir.
+        let watch_pat = format!("{}/sudoers", dir.path().display());
+        let watches = vec![WatchSpec {
+            category: Category::Sudoers,
+            patterns: vec![Box::leak(watch_pat.into_boxed_str())],
+        }];
+        let cfg = SentryConfig {
+            baseline_path: baseline_path.clone(),
+            watches,
+        };
+
+        let alerts: RefCell<Vec<(String, String, String)>> = RefCell::new(vec![]);
+        let report = run_with_config(&cfg, |sev, src, msg, _| {
+            alerts.borrow_mut().push((sev.into(), src.into(), msg.into()));
+        });
+
+        assert!(!report.first_run);
+        assert_eq!(report.changed.len(), 1);
+        assert_eq!(alerts.borrow().len(), 1);
+        let (sev, src, _msg) = &alerts.borrow()[0];
+        assert_eq!(sev, "critical");
+        assert_eq!(src, "sentry/sudoers");
+    }
+
+    #[test]
+    fn diff_reports_added_removed_changed() {
+        let mut prev = BTreeMap::new();
+        prev.insert(
+            "/a".into(),
+            BaselineEntry { category: "x".into(), sha256: "1".into() },
+        );
+        prev.insert(
+            "/b".into(),
+            BaselineEntry { category: "x".into(), sha256: "2".into() },
+        );
+        let mut cur = BTreeMap::new();
+        cur.insert(
+            "/a".into(),
+            BaselineEntry { category: "x".into(), sha256: "1".into() },
+        );
+        cur.insert(
+            "/c".into(),
+            BaselineEntry { category: "x".into(), sha256: "3".into() },
+        );
+        let (added, removed, changed) = diff(&prev, &cur);
+        assert_eq!(added, vec!["/c"]);
+        assert_eq!(removed, vec!["/b"]);
+        assert!(changed.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3070,6 +3070,7 @@ AVAILABLE COMMANDS:
   run-tool <name>          Run specific security tool
   legion <options>         LEGION security monitoring
   --security-report        Generate comprehensive security assessment
+  --sentry-check           Diff high-value files against baseline (cron-friendly)
   --enable-selinux         ⚠️  Enable SELinux (DISABLES AppArmor, REQUIRES REBOOT)
   --uninstall [flags]      Uninstall HARDN (see --uninstall --help for flags)
 
@@ -3153,6 +3154,37 @@ fn handle_run_tool(tool_dirs: &[PathBuf], tool_name: &str, module_dirs: &[PathBu
             EXIT_NOT_FOUND
         }
     }
+}
+
+/// Run the sentry baseline-diff check. Prints a short report and exits 0
+/// on success — alerts are emitted via the shared alert channel.
+fn run_sentry_check() -> i32 {
+    let report = crate::legion::modules::sentry::run_check();
+    if report.first_run {
+        println!(
+            "[sentry] baseline created ({} files watched). No alerts on first run.",
+            report.watched_files
+        );
+    } else {
+        println!(
+            "[sentry] watched={} added={} removed={} changed={} (total={})",
+            report.watched_files,
+            report.added.len(),
+            report.removed.len(),
+            report.changed.len(),
+            report.total_changes()
+        );
+        for p in &report.added {
+            println!("  + {}", p);
+        }
+        for p in &report.removed {
+            println!("  - {}", p);
+        }
+        for p in &report.changed {
+            println!("  ~ {}", p);
+        }
+    }
+    EXIT_SUCCESS
 }
 
 /// Run the LEGION monitoring tool
@@ -3268,6 +3300,7 @@ fn main() {
                     EXIT_SUCCESS
                 }
                 "--enable-selinux" | "enable-selinux" => enable_selinux(),
+                "--sentry-check" | "sentry-check" => run_sentry_check(),
                 _ => {
                     log_message(LogLevel::Error, &format!("Unknown option: {}", args[1]));
                     print_help();

--- a/src/utils/alerts.rs
+++ b/src/utils/alerts.rs
@@ -7,19 +7,41 @@
 //! Producers:
 //! - `hardn-monitor` (service down / restart success / restart failure)
 //! - `hardn legion` daemon (risk threshold breaches, automated response)
+//! - `hardn --sentry-check` (high-value file drift)
 //!
 //! The protocol field set is intentionally small: `ts`, `severity`,
 //! `source`, `message`, `key`. Severities used today: `info`, `warning`,
 //! `error`, `critical`.
+//!
+//! After writing to the JSONL file, `emit_alert` also forwards to two
+//! optional out-of-band sinks (see `AlertSinks`):
+//!   * **journald** — every alert is logged to the system journal under
+//!     the `HARDN-ALERT` syslog tag, so `journalctl -t HARDN-ALERT` and
+//!     existing log-forwarders pick them up with zero extra plumbing.
+//!   * **webhook** — when `$HARDN_ALERT_WEBHOOK_URL` is set, the same
+//!     payload is POSTed (via curl) to that URL.
+//!
+//! Both sinks honour a TTL-based dedupe (default 6h) keyed by `key`, so a
+//! noisy condition can't pager-spam an on-call.
 
 use chrono::Utc;
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Default path for the alert sink. Producers can override via
 /// `emit_alert_to` if they need a different location (e.g. tests).
 pub const DEFAULT_ALERTS_PATH: &str = "/var/log/hardn/alerts.jsonl";
+
+/// File backing the dedupe cache for journald + webhook forwarding.
+const DEFAULT_DEDUPE_PATH: &str = "/var/lib/hardn/alerts/seen.json";
+/// Default dedupe window. Operators override with `$HARDN_ALERT_DEDUPE_TTL_SEC`.
+const DEFAULT_DEDUPE_TTL_SEC: u64 = 6 * 3600;
+/// Hard cap on curl webhook duration so a slow receiver can't stall the caller.
+const WEBHOOK_TIMEOUT_SEC: u64 = 10;
 
 /// Build one JSON-lines payload. Pure function so callers can test
 /// formatting without touching disk.
@@ -54,7 +76,8 @@ pub fn emit_alert_to(path: &Path, severity: &str, source: &str, message: &str, k
     }
 }
 
-/// Convenience wrapper that emits to the default `/var/log/hardn/alerts.jsonl`.
+/// Convenience wrapper that emits to the default `/var/log/hardn/alerts.jsonl`
+/// AND fans out to the journald + (optional) webhook sinks with dedupe.
 pub fn emit_alert(severity: &str, source: &str, message: &str, key: &str) {
     emit_alert_to(
         &PathBuf::from(DEFAULT_ALERTS_PATH),
@@ -63,6 +86,198 @@ pub fn emit_alert(severity: &str, source: &str, message: &str, key: &str) {
         message,
         key,
     );
+    AlertSinks::from_env().forward(severity, source, message, key);
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-band sinks: journald + webhook, with shared TTL dedupe.
+// ---------------------------------------------------------------------------
+
+/// Configurable sink fan-out. Reads config from environment so producers don't
+/// need to thread a settings struct through every call site. Each sink is
+/// gated by a dedupe cache keyed by `key` so noisy conditions don't pager-spam.
+#[derive(Debug, Clone)]
+pub struct AlertSinks {
+    pub dedupe_path: PathBuf,
+    pub dedupe_ttl_sec: u64,
+    pub journald_tag: String,
+    pub webhook_url: Option<String>,
+    /// When true, never fork curl / systemd-cat. Used by the unit tests.
+    pub silent: bool,
+}
+
+impl AlertSinks {
+    /// Read sink configuration from environment variables. All keys optional:
+    ///   `HARDN_ALERT_WEBHOOK_URL`      — POST destination
+    ///   `HARDN_ALERT_DEDUPE_TTL_SEC`   — dedupe window (default 6h)
+    ///   `HARDN_ALERT_DEDUPE_PATH`      — override cache path (default /var/lib/hardn/alerts/seen.json)
+    ///   `HARDN_ALERT_JOURNALD_TAG`     — syslog tag (default HARDN-ALERT)
+    pub fn from_env() -> Self {
+        let dedupe_ttl_sec = std::env::var("HARDN_ALERT_DEDUPE_TTL_SEC")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_DEDUPE_TTL_SEC);
+        let dedupe_path = std::env::var("HARDN_ALERT_DEDUPE_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_DEDUPE_PATH));
+        let journald_tag = std::env::var("HARDN_ALERT_JOURNALD_TAG")
+            .unwrap_or_else(|_| "HARDN-ALERT".to_string());
+        let webhook_url = std::env::var("HARDN_ALERT_WEBHOOK_URL")
+            .ok()
+            .filter(|s| !s.is_empty());
+        Self {
+            dedupe_path,
+            dedupe_ttl_sec,
+            journald_tag,
+            webhook_url,
+            silent: false,
+        }
+    }
+
+    /// Forward to journald + webhook unless the dedupe cache says we've sent
+    /// this `key` recently. Errors are swallowed.
+    pub fn forward(&self, severity: &str, source: &str, message: &str, key: &str) {
+        if self.silent {
+            return;
+        }
+        if self.is_deduped(key) {
+            return;
+        }
+        self.send_journald(severity, source, message);
+        if let Some(url) = &self.webhook_url {
+            let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let payload = build_alert_payload(&ts, severity, source, message, key);
+            self.send_webhook(url, &payload);
+        }
+        self.mark_sent(key);
+    }
+
+    /// Returns true if `key` was forwarded inside the current TTL window.
+    fn is_deduped(&self, key: &str) -> bool {
+        let now = unix_now();
+        let cache = load_dedupe(&self.dedupe_path);
+        match cache.get(key) {
+            Some(&last) => now.saturating_sub(last) < self.dedupe_ttl_sec,
+            None => false,
+        }
+    }
+
+    fn mark_sent(&self, key: &str) {
+        let mut cache = load_dedupe(&self.dedupe_path);
+        let now = unix_now();
+        // Garbage-collect stale entries so the file doesn't grow forever.
+        cache.retain(|_, last| now.saturating_sub(*last) < self.dedupe_ttl_sec.saturating_mul(2));
+        cache.insert(key.to_string(), now);
+        save_dedupe(&self.dedupe_path, &cache);
+    }
+
+    /// Pipe the alert text into `systemd-cat` so it lands in journald under
+    /// the configured tag with a meaningful priority. Falls back to `logger`
+    /// when systemd-cat isn't present (eg. on non-systemd init systems).
+    fn send_journald(&self, severity: &str, source: &str, message: &str) {
+        let priority = match severity {
+            "critical" => "crit",
+            "error" => "err",
+            "warning" => "warning",
+            "info" => "info",
+            _ => "notice",
+        };
+        let line = format!("[{}] {}", source, message);
+
+        if Path::new("/usr/bin/systemd-cat").exists()
+            || Path::new("/bin/systemd-cat").exists()
+        {
+            let mut child = match Command::new("systemd-cat")
+                .args(["-t", &self.journald_tag, "-p", priority])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(_) => return,
+            };
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(line.as_bytes());
+            }
+            let _ = child.wait();
+            return;
+        }
+
+        // logger(1) fallback — universally available on Debian.
+        let _ = Command::new("logger")
+            .args(["-t", &self.journald_tag, "-p", &format!("user.{}", priority), "--", &line])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    /// POST the alert JSON to the configured webhook. We shell out to curl
+    /// because HARDN already depends on it and adding reqwest doubles compile
+    /// times. Body is piped via stdin (`-d @-`) so no shell escaping is needed.
+    fn send_webhook(&self, url: &str, payload: &str) {
+        // Quick URL sanity check — only http(s) URLs allowed.
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            return;
+        }
+        if !Path::new("/usr/bin/curl").exists() && !Path::new("/bin/curl").exists() {
+            return;
+        }
+        let mut child = match Command::new("curl")
+            .args([
+                "-fsS",
+                "-m", &WEBHOOK_TIMEOUT_SEC.to_string(),
+                "-X", "POST",
+                "-H", "Content-Type: application/json",
+                "--data-binary", "@-",
+                url,
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(payload.as_bytes());
+        }
+        let _ = child.wait();
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn load_dedupe(path: &Path) -> HashMap<String, u64> {
+    match fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+fn save_dedupe(path: &Path, cache: &HashMap<String, u64>) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("tmp");
+    if let Ok(mut f) = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&tmp)
+    {
+        if serde_json::to_writer(&mut f, cache).is_ok() && f.flush().is_ok() {
+            let _ = fs::rename(&tmp, path);
+        } else {
+            let _ = fs::remove_file(&tmp);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -106,5 +321,54 @@ mod tests {
         let v1: serde_json::Value = serde_json::from_str(lines[1]).expect("line 1 json");
         assert_eq!(v0["severity"], "error");
         assert_eq!(v1["severity"], "warning");
+    }
+
+    fn make_silent_sinks(tmp_dir: &Path) -> AlertSinks {
+        AlertSinks {
+            dedupe_path: tmp_dir.join("seen.json"),
+            dedupe_ttl_sec: 60,
+            journald_tag: "test".into(),
+            webhook_url: None,
+            silent: false, // we want forward()'s dedupe logic to run; silent disables side effects below
+        }
+    }
+
+    #[test]
+    fn dedupe_blocks_second_call_within_ttl() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut sinks = make_silent_sinks(dir.path());
+        sinks.silent = true; // make forward() a no-op past the dedupe check
+        // is_deduped is the gate we actually want to test
+        assert!(!sinks.is_deduped("k"));
+        sinks.mark_sent("k");
+        assert!(sinks.is_deduped("k"));
+    }
+
+    #[test]
+    fn dedupe_releases_after_ttl_expiry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sinks = AlertSinks {
+            dedupe_path: dir.path().join("seen.json"),
+            dedupe_ttl_sec: 0, // expires immediately
+            journald_tag: "test".into(),
+            webhook_url: None,
+            silent: true,
+        };
+        sinks.mark_sent("k");
+        assert!(!sinks.is_deduped("k"));
+    }
+
+    #[test]
+    fn from_env_falls_back_to_defaults() {
+        // Don't touch env in tests (parallelism); just check struct defaults.
+        let sinks = AlertSinks {
+            dedupe_path: PathBuf::from(DEFAULT_DEDUPE_PATH),
+            dedupe_ttl_sec: DEFAULT_DEDUPE_TTL_SEC,
+            journald_tag: "HARDN-ALERT".into(),
+            webhook_url: None,
+            silent: true,
+        };
+        assert_eq!(sinks.dedupe_ttl_sec, 6 * 3600);
+        assert_eq!(sinks.journald_tag, "HARDN-ALERT");
     }
 }


### PR DESCRIPTION
## Summary

PR-C — phase 1 of the **LEGION tattletale** roadmap. Turns HARDN from reactive logging into proactive alerting against the four classic Linux persistence vectors (authorized_keys, sudoers, cron, systemd units) plus passwd/shadow.

### New: sentry module + `hardn --sentry-check`

`src/legion/modules/sentry/mod.rs` — sha256-based baseline diff against a curated, high-signal watch list:

| Category | Paths | Severity on drift |
|---|---|---|
| `passwd_shadow` | `/etc/passwd` `/etc/shadow` `/etc/gshadow` `/etc/group` | warning |
| `sudoers` | `/etc/sudoers` `/etc/sudoers.d/*` | **critical** |
| `authorized_keys` | `/root/.ssh/authorized_keys{,2}` `/home/*/.ssh/authorized_keys{,2}` | **critical** |
| `cron` | `/etc/crontab` `/etc/cron.{d,daily,hourly,weekly,monthly}/*` `/var/spool/cron/{,crontabs/}*` | warning |
| `systemd` | `/etc/systemd/system/*.{service,timer,socket,path}` `/etc/systemd/system/*.d/*.conf` | warning |

Baseline lives at `/var/lib/hardn/sentry/baseline.json`, written atomically via `rename(2)`. First run is silent; subsequent runs emit one `emit_alert()` per added / removed / changed file.

New cron job `hardn-sentry` runs daily at 02:15 (quiet window after the 01:30 legion baseline).

### Alert sink fanout

Every `emit_alert()` call now ALSO fans out to two out-of-band sinks (gated by a shared TTL dedupe so noisy conditions can't pager-spam):

| Sink | Mechanism | Config |
|---|---|---|
| journald | `systemd-cat -t HARDN-ALERT -p <prio>` (falls back to `logger(1)`) | `HARDN_ALERT_JOURNALD_TAG` (default `HARDN-ALERT`) |
| webhook | `curl -fsS -m 10 -X POST -H 'Content-Type: application/json' --data-binary @-` | `HARDN_ALERT_WEBHOOK_URL` (http(s) only) |

Dedupe cache: `/var/lib/hardn/alerts/seen.json`, keyed by the alert's `key` field, default TTL 6h, override via `HARDN_ALERT_DEDUPE_TTL_SEC`. No new compile-time deps — `curl` is already a HARDN runtime dep.

## Test plan

- [x] `cargo test --bin hardn` → **17 passed** (was 11; +6 new)
  - `alerts::tests::{dedupe_blocks_second_call_within_ttl,dedupe_releases_after_ttl_expiry,from_env_falls_back_to_defaults}`
  - `sentry::tests::{first_run_writes_baseline_and_alerts_nothing,change_emits_alert_with_correct_severity,diff_reports_added_removed_changed}`
- [x] `cargo check --bins` → clean
- [x] End-to-end smoke on the CI runner: `touch /etc/cron.d/hardn-test-fake` → `hardn --sentry-check` reports `+` for that path → `/var/log/hardn/alerts.jsonl` receives `severity=warning, source=sentry/cron, key=sentry:cron:added:/etc/cron.d/hardn-test-fake`
- [x] No "claude" / "anthropic" / "copilot" strings in any modified file
- [ ] CI passes on this PR
- [ ] On a real host with `HARDN_ALERT_WEBHOOK_URL=…` set: alerts arrive at the webhook receiver as JSON
- [ ] Two back-to-back alerts with the same key in the 6h window: only the first fires journald/webhook (jsonl always gets both — `alerts.jsonl` is the canonical record, sinks are filtered fanout)

## Up next

- **PR-E** — GUI guidance + in-GUI uninstall (welcome panel, tooltips, tool inventory list, "Uninstall HARDN" menu item, profile.d / desktop launcher cleanup gaps)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_