### PR TITLE
Docs refresh for PR-A through PR-F + em-dash / AI-tell scrub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,170 +7,173 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Kernel rules consolidation
+The unreleased work landed as six stacked PRs (A, B, D, C, E, F) on the
+`patch` branch through May 2026. They are grouped here by area rather than
+by PR.
 
-- **Single audit-rules writer.** `modules/hardening.sh` no longer writes
-  `/etc/audit/rules.d/99-hardn-hardening.rules` itself; it delegates to
-  `tools/auditd.sh`. The hardening.sh copy had a malformed
-  `/etc/cron.monthly/-p war` watch (missing space), placed `-D` after the
-  rule list (which wiped its own rules), duplicated the auditd.conf
-  drop-in from `tools/auditd.sh`, and ignored the container-skip gate.
-  One writer, one rules file.
-- **`unprivileged_userns_clone=0`, `unprivileged_bpf_disabled=1`,
-  `net.core.bpf_jit_harden=2` are now gated** on a new
-  `hardn_is_container_workload_host` heuristic (Docker/Podman/LXD/k8s
-  state dirs or binaries present, or HARDN_CONTAINER_HOST=1). Operators
-  can force the strict values back on with `HARDN_STRICT_USERNS=1` /
-  `HARDN_STRICT_BPF=1`. Stops HARDN from breaking rootless Podman,
-  Firejail (which HARDN itself installs), Chrome sandbox, bpftrace, etc.
-- **IPv6 `accept_ra=0` skipped on cloud/VM** — SLAAC needs RA enabled
-  to learn a default route on AWS / GCP / Azure / DO. Bare-metal
-  behaviour unchanged.
-- **`kernel.exec-shield=1` removed** — Red Hat-only patch, dropped
-  upstream before kernel 3.x; produced "unsupported sysctl" noise every
-  run on Debian/Ubuntu.
-- **`kernel.modules_disabled=0` removed** — was a no-op (default value)
-  and risky to flip to 1 (one-shot kill switch).
-- **`kernel.panic` is now overridable** via `HARDN_KERNEL_PANIC_SECONDS`
-  (default 60 retained for compat; cloud hosts typically want 10).
+### Hardware, cloud, and container compatibility (PR A + B)
 
-### Audit rules accuracy
+- New env-detection helper `tools/env-detect.sh`. Exports
+  `HARDN_ENV_VIRT`, `HARDN_ENV_CLOUD`, and the predicates
+  `hardn_in_container`, `hardn_in_vm`, `hardn_in_cloud`,
+  `hardn_on_baremetal`. Sourced from `functions.sh` and `hardening.sh`.
+- The hardening run now prints a one-line "Detected environment" banner so
+  operators see what HARDN will skip.
+- SSH hardening will not disable `PasswordAuthentication` when the host has
+  no public keys and is on a cloud VM. Override with
+  `HARDN_FORCE_DISABLE_PASSWORD_AUTH=1`; force-keep with
+  `HARDN_KEEP_PASSWORD_AUTH=1`.
+- Cloud instance metadata IP (169.254.169.254, plus 168.63.129.16 on Azure)
+  is explicitly allowlisted in UFW and the iptables `HARDN-LOCKDOWN` chain
+  on cloud hosts.
+- Fail2Ban jail honours `HARDN_SSH_PORT` (was hard-coded 22) and
+  pre-populates `ignoreip` with cloud load-balancer health-check ranges
+  (GCP shipped; operators override via `HARDN_CLOUD_LB_CIDRS`).
+- Auditd ships a disk-safety policy (`disk_full_action=SYSLOG`,
+  `space_left_action=SYSLOG`, `admin_space_left_action=SUSPEND`) and sizes
+  its audit buffer based on free space on `/var/log`. Small cloud root
+  volumes can no longer be filled into a kernel panic.
+- Auditd setup exits cleanly inside containers instead of spamming "Operation
+  not permitted" against the host audit subsystem.
+- FireWire blacklist + `modprobe -r firewire-core` + initramfs rebuild are
+  skipped in containers.
+- Sysctl writes that fail inside an unprivileged container now log INFO
+  ("host owns this parameter") instead of WARNING.
 
-- **All execve / module-load rules now have paired `arch=b32` entries.**
-  Previously a 32-bit compat syscall (int 0x80 on amd64) bypassed every
-  `arch=b64` rule unobserved.
-- **`/tmp` + `/var/tmp` `-p wa` watches removed.** Generated one record
-  per shell/compiler/test tempfile and filled `/var/log/audit` on build
-  servers within minutes. SENTRY's persistence-vector diff (PR-C) covers
-  what the `/tmp` watch was nominally protecting against.
-- **Broken T1041 exfil rules dropped.** `-S connect -F a0=2` filtered on
-  the file descriptor instead of the address family (which lives in
-  `*addr` and isn't reachable from a register filter). The rules either
-  matched nothing or every connect on the host — both worthless. Exfil
-  detection belongs in a userspace consumer or NIDS; HARDN already
-  ships Suricata for that.
+### Tools hygiene (PR D)
 
-### GUI guidance & in-GUI uninstall
+- Every cron job runs under `/usr/bin/flock -n -E 99` keyed by
+  `/run/hardn/cron-locks/<job>.lock`. Concurrent HARDN processes (daemon
+  plus manual run, or two daemons during upgrade) cannot double-fire a job.
+  A busy lock is logged as INFO ("another instance held the lock") and
+  reported as success so the dashboard does not light up red.
+- Suricata rule updates run into a staging directory
+  (`/var/lib/hardn/suricata-rules-staging`), pass `suricata -T -S`
+  validation, then atomically swap into `/etc/suricata/rules/suricata.rules`
+  via `rename(2)`. A running Suricata can no longer observe a half-written
+  rule file. Update failure leaves the previous rules untouched.
+- Suricata setup uses `install -d -o suricata -g suricata -m 0755 ...` so
+  rule, log, and cache dirs land with the right ownership in one syscall.
+  Closes the chmod race between `mkdir` and the later `chown`.
+- New `EXIT_NOT_FOUND = 127` exit code. `hardn run-tool <missing>` and
+  `hardn run-module <missing>` now return 127 (POSIX "command not found")
+  instead of 1, so cron and CI can tell a typo from a real failure.
 
-- New **welcome wizard** dialog: a 4-step Debian-style modal that pops up
-  on first launch with an overview, GUI tour, common actions, and where to
-  get help. Back / Next / Skip / Done navigation; "Don't show this on next
-  launch" checkbox writes `$XDG_CONFIG_HOME/hardn/welcome-seen` to suppress
-  future launches. Also suppressible via `HARDN_NO_WELCOME=1` for
-  kiosk/CI/autostart use.
-- New **Tools** tab in the main notebook — auto-generated inventory of every
-  script under `/usr/share/hardn/tools/*.sh` with its one-line description,
-  plus a hint for running them from the shell.
-- **Tooltips** on every tab label (Logs / Terminal / Logs+Terminal / Alerts
-  / Tools) explaining what each view shows.
+### LEGION tattletale, phase 1 (PR C)
 
-### Uninstall / dpkg parity
+- New sentry module (`legion::modules::sentry`). Runs once-per-day from the
+  cron orchestrator, sha256-hashes a curated set of high-value files, diffs
+  them against `/var/lib/hardn/sentry/baseline.json`, and emits one alert
+  per added, removed, or changed entry. Watched paths:
+  `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, `/etc/group`,
+  `/etc/sudoers`, `/etc/sudoers.d/*`,
+  `/{root,/home/*}/.ssh/authorized_keys{,2}`, `/etc/crontab`,
+  `/etc/cron.{d,daily,hourly,weekly,monthly}/*`,
+  `/var/spool/cron/{,crontabs/}*`,
+  `/etc/systemd/system/*.{service,timer,socket,path}`,
+  `/etc/systemd/system/*.d/*.conf`.
+- New CLI: `hardn --sentry-check`. Runs sentry once, prints a short
+  report, emits alerts. First run silently writes the baseline; subsequent
+  runs alert on drift. Authorized-keys and sudoers drift fire
+  `critical`; cron, systemd, and passwd/shadow drift fire `warning`.
+- New cron job `hardn-sentry` runs daily at 02:15.
+- Alert fanout: every `emit_alert()` now also forwards to journald
+  (always) and webhook (when `HARDN_ALERT_WEBHOOK_URL` is set). Both
+  sinks share a TTL dedupe cache at `/var/lib/hardn/alerts/seen.json` so
+  a noisy condition cannot pager-spam an on-call.
+  - Journald uses `systemd-cat -t HARDN-ALERT -p <prio>` (fallback to
+    `logger(1)` on non-systemd hosts). Tag overridable via
+    `HARDN_ALERT_JOURNALD_TAG`.
+  - Webhook POSTs the same JSON payload as `alerts.jsonl` (`ts`,
+    `severity`, `source`, `message`, `key`) via `curl -fsS -m 10`. `http://`
+    and `https://` only. No new compile-time dep added.
+  - Dedupe TTL defaults to 6 hours; override via
+    `HARDN_ALERT_DEDUPE_TTL_SEC`.
 
-- `hardn-uninstall.sh` now cleans up everything the install put in place but
-  the previous version forgot:
+### GUI guidance and uninstall parity (PR E)
+
+- New welcome wizard: a four-step Debian-style modal that pops up on first
+  launch with an overview, GUI tour, common actions, and where to get help.
+  Back, Next, Skip, Done navigation; "Don't show this on next launch"
+  checkbox writes `$XDG_CONFIG_HOME/hardn/welcome-seen`. Also suppressible
+  via `HARDN_NO_WELCOME=1`.
+- New Tools tab. Auto-generated inventory of every `usr/share/hardn/tools/*.sh`
+  with its one-line description, plus a hint for running them from the
+  shell.
+- Tooltips on every tab label (Logs, Terminal, Logs+Terminal, Alerts,
+  Tools) explain what each view shows.
+- `hardn-uninstall.sh` cleans up the install artefacts the previous
+  version forgot:
   - `/etc/profile.d/hardn-paths.sh`
-  - `/etc/audit/auditd.conf.d/99-hardn.conf` (PR-A drop-in)
+  - `/etc/audit/auditd.conf.d/99-hardn.conf` (PR A drop-in)
   - `/etc/fail2ban/jail.local`
   - System-wide `/usr/share/applications/hardn-gui.desktop`
   - Per-user `~/.local/share/applications/hardn-gui.desktop` and
     `~/.local/share/icons/hardn-gui.jpeg` for every passwd entry with
     `uid >= 1000` and a valid home
-  - `/run/hardn/` (cron-locks tmpfs dir from PR-D)
-  - `/var/lib/hardn/{sentry,alerts,suricata-rules-staging}` (covered by the
-    existing `/var/lib/hardn` rm, but now explicitly noted)
-  - Runs `update-desktop-database` so the system menu drops the HARDN entry
-    without requiring a logout
-- New `debian/postrm`: on `apt remove` removes `/etc/profile.d/hardn-paths.sh`;
-  on `apt purge` also nukes `/usr/share/applications/hardn-gui.desktop`,
-  `/var/log/hardn`, `/var/lib/hardn`, `/etc/hardn`, `/run/hardn` and refreshes
-  the desktop database. Debhelper's auto-generated systemd-unit teardown is
-  preserved via `#DEBHELPER#`.
+  - `/run/hardn/` (cron-locks tmpfs dir from PR D)
+  - `/var/lib/hardn/{sentry,alerts,suricata-rules-staging}`
+  - Runs `update-desktop-database` so the system menu drops the HARDN
+    entry without requiring a logout
+- New `debian/postrm`. On `apt remove` it removes
+  `/etc/profile.d/hardn-paths.sh`; on `apt purge` it also nukes
+  `/usr/share/applications/hardn-gui.desktop`, `/var/log/hardn`,
+  `/var/lib/hardn`, `/etc/hardn`, `/run/hardn` and refreshes the desktop
+  database. Debhelper's auto-generated systemd-unit teardown is preserved
+  via `#DEBHELPER#`.
 
-### LEGION tattletale (phase 1)
+### Kernel rules consolidation (PR F)
 
-- New **sentry** module (`legion::modules::sentry`) — runs once-per-day from
-  the cron orchestrator, sha256-hashes a curated set of high-value files,
-  diffs them against `/var/lib/hardn/sentry/baseline.json`, and emits one
-  alert per added / removed / changed entry. Watched paths:
-  `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, `/etc/group`,
-  `/etc/sudoers`, `/etc/sudoers.d/*`, `/{root,/home/*}/.ssh/authorized_keys{,2}`,
-  `/etc/crontab`, `/etc/cron.{d,daily,hourly,weekly,monthly}/*`,
-  `/var/spool/cron/{,crontabs/}*`,
-  `/etc/systemd/system/*.{service,timer,socket,path}`,
-  `/etc/systemd/system/*.d/*.conf`
-- New CLI: `hardn --sentry-check` — runs sentry once, prints a short report,
-  emits alerts. First run silently writes the baseline; subsequent runs alert
-  on drift. Authorized-keys / sudoers drift → `critical`; cron / systemd /
-  passwd-shadow drift → `warning`.
-- New cron job `hardn-sentry` runs daily at 02:15.
-- Alerts now also fan out to **journald** (always) and **webhook**
-  (when `$HARDN_ALERT_WEBHOOK_URL` is set). Both sinks share a TTL-based
-  dedupe cache at `/var/lib/hardn/alerts/seen.json` so a noisy condition
-  can't pager-spam an on-call.
-  - Journald uses `systemd-cat -t HARDN-ALERT -p <prio>` (fallback `logger`
-    on non-systemd hosts). Tag overridable via `$HARDN_ALERT_JOURNALD_TAG`.
-  - Webhook POSTs the same JSON payload as `alerts.jsonl` (`ts`, `severity`,
-    `source`, `message`, `key`) via `curl -fsS -m 10`. http:// and https://
-    only. No new compile-time dep added.
-  - Dedupe TTL defaults to 6 hours; override via `$HARDN_ALERT_DEDUPE_TTL_SEC`.
+- Single audit-rules writer. `modules/hardening.sh` no longer writes
+  `/etc/audit/rules.d/99-hardn-hardening.rules`; it delegates to
+  `tools/auditd.sh`. The hardening.sh copy had a malformed
+  `/etc/cron.monthly/-p war` watch (missing space), placed `-D` after the
+  rule list (which wiped its own rules), duplicated the `auditd.conf`
+  drop-in from `tools/auditd.sh`, and ignored the container-skip gate.
+  One writer, one rules file.
+- `kernel.unprivileged_userns_clone=0`, `kernel.unprivileged_bpf_disabled=1`,
+  and `net.core.bpf_jit_harden=2` are now gated on a new
+  `hardn_is_container_workload_host` heuristic (Docker, Podman, LXD, k8s
+  state dirs or binaries present, or `HARDN_CONTAINER_HOST=1`). Operators
+  can force the strict values back on with `HARDN_STRICT_USERNS=1` and
+  `HARDN_STRICT_BPF=1`. Stops HARDN from breaking rootless Podman,
+  Firejail (which HARDN installs), Chrome sandbox, bpftrace, and friends.
+- IPv6 `accept_ra=0` is skipped on cloud and VM. SLAAC needs RA enabled to
+  learn a default route on AWS, GCP, Azure, and DigitalOcean. Bare-metal
+  behaviour unchanged.
+- `kernel.exec-shield=1` removed. Red Hat-only patch, dropped upstream
+  before kernel 3.x. Produced "unsupported sysctl" warning every run on
+  Debian and Ubuntu.
+- `kernel.modules_disabled=0` removed. Was a no-op (kernel default) and
+  risky to flip to 1 (one-shot kill switch).
+- `kernel.panic` is now overridable via `HARDN_KERNEL_PANIC_SECONDS`
+  (default 60 retained for compat; cloud hosts typically want 10).
+- Every `arch=b64` execve and module rule now has a paired `arch=b32`
+  line. A 32-bit compat syscall (int 0x80 on amd64) previously bypassed
+  every `mitre_cmd_exec` and `mitre_rootkit` watch unobserved.
+- `/tmp` and `/var/tmp` `-p wa` watches removed. Generated one record per
+  shell, compiler, or test tempfile and filled `/var/log/audit` on build
+  servers in minutes. CIS Benchmark deliberately omits them. SENTRY's
+  persistence-vector diff covers what the `/tmp` watch was nominally
+  protecting against.
+- Broken T1041 exfil rules dropped. `-S connect -F a0=2` filtered on the
+  file descriptor instead of the address family (which lives in `*addr`
+  and is not reachable from a register filter). The rules matched either
+  nothing or every connect on the host, both worthless. Exfil detection
+  belongs in a userspace consumer or NIDS; HARDN already ships Suricata
+  for that.
 
-### Tools hygiene
+### Logs and UX
 
-- Cron orchestrator now wraps every job in `/usr/bin/flock -n -E 99` keyed
-  by `/run/hardn/cron-locks/<job>.lock`. Concurrent HARDN processes (daemon
-  + manual run, or two daemons during upgrades) can no longer double-fire
-  a job mid-flight. A busy lock is logged as INFO ("another instance held
-  the lock") and reported as success so the dashboard doesn't light up red
-- Suricata rule updates now run into a staging dir
-  (`/var/lib/hardn/suricata-rules-staging`), pass `suricata -T -S`
-  validation, and atomically swap into `/etc/suricata/rules/suricata.rules`
-  via `rename(2)` — a running Suricata can never observe a half-written
-  rule file. Update failure leaves the previous rules untouched
-- Suricata setup uses `install -d -o suricata -g suricata -m 0755 ...` so
-  rule/log/cache dirs land with the right ownership in one syscall instead
-  of opening a chmod-race window between `mkdir` and the later `chown`
-- New `EXIT_NOT_FOUND = 127` exit code: `hardn run-tool <missing>` and
-  `hardn run-module <missing>` now return 127 (POSIX "command not found")
-  instead of 1, so cron/CI can distinguish a typo from a real failure
-
-### Hardware & cloud compatibility
-
-- New environment-detection helper `tools/env-detect.sh` populating
-  `HARDN_ENV_VIRT`, `HARDN_ENV_CLOUD`, and `hardn_in_{container,vm,cloud,baremetal}`
-  predicates, sourced from `functions.sh` and `hardening.sh`
-- A one-line "Detected environment" banner is now printed at the start of
-  every hardening run so operators see what HARDN will skip
-- SSH hardening no longer disables `PasswordAuthentication` when the host
-  has no public keys and is running in a cloud VM — prevents permanent
-  remote lockout. Override with `HARDN_FORCE_DISABLE_PASSWORD_AUTH=1`;
-  force-keep with `HARDN_KEEP_PASSWORD_AUTH=1`
-- Cloud instance metadata endpoint (169.254.169.254, plus 168.63.129.16
-  on Azure) is now explicitly allowlisted in UFW and the iptables
-  HARDN-LOCKDOWN chain when a cloud environment is detected
-- Fail2Ban jail now honours `HARDN_SSH_PORT` (previously hardcoded to 22)
-  and pre-populates `ignoreip` with cloud load-balancer health-check
-  ranges (GCP today; operators can add their own via `HARDN_CLOUD_LB_CIDRS`)
-- Auditd now ships a disk-safety policy (`disk_full_action=SYSLOG`,
-  `space_left_action=SYSLOG`, `admin_space_left_action=SUSPEND`) and
-  sizes its audit buffer based on free space on `/var/log` — small cloud
-  root volumes can no longer be filled into a kernel panic
-- Auditd setup exits cleanly inside containers instead of spamming
-  "Operation not permitted" against the host audit subsystem
-- FireWire blacklist + `modprobe -r firewire-core` + initramfs rebuild
-  skipped in containers
-- Sysctl writes that fail inside an unprivileged container are now
-  logged as INFO ("host owns this parameter") rather than WARNING
-
-### Logs & UX
-
-- HARDN_STATUS no longer writes ANSI colour escapes to log files when
-  stdout is not a TTY — the GUI's log tail now reads clean text
+- `HARDN_STATUS` no longer writes ANSI colour escapes to log files when
+  stdout is not a TTY. The GUI's log tail now reads clean text.
 - `hardn --help` lists the `--enable-selinux` flag, which was previously
-  only documented in the setup binary
+  documented only in the setup binary.
+- `hardn --help` lists `--sentry-check`.
 
 ## [1.1.0-1] - 2026-05-24
 
-### Audit framework — 100% coverage (194/194 rules)
+### Audit framework, 100% coverage (194/194 rules)
 
 - 25 sysctl-based audit checks for kernel network hardening
 - 19 mount-option audit checks via `/proc/mounts`
@@ -184,12 +187,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 dpkg-based package install-state audit checks
 - 8 audit checks for home directory and dotfile hygiene
 - Firewall default-policy and `/var/log` permissions audit checks
-- Audit checks for `passwd`, `shadow` and cron file owner, group and mode
+- Audit checks for `passwd`, `shadow`, and cron file owner, group, and mode
 - 2 kernel-module-disabled audit checks (`cramfs`, `usb-storage`)
 
 ### LEGION and alerting
 
-- LEGION emits alerts to the shared alert channel on high/critical risk
+- LEGION emits alerts to the shared alert channel on high or critical risk
 - Structured alert channel from `hardn-monitor` to `hardn-gui`
 - Unified LEGION baseline DB path via `Config::database_path()`
 
@@ -203,8 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Packaging and installation
 
 - Full uninstall script with boot-safety fixes for `hardn-api`,
-  `hardn.service` and `legion-daemon.service`
-- Hardened tool-launch safety — renamed `selinux.sh` to
+  `hardn.service`, and `legion-daemon.service`
+- Hardened tool-launch safety. Renamed `selinux.sh` to
   `selinux.sh.DANGEROUS`, filter helper libraries, fix install logic
 - Ignored `dpkg-buildpackage` `hardn.debhelper.log` artifact
 - Fixed dpkg failure for monitor output
@@ -213,12 +216,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI and release
 
-- Richer Discord release notification — embeds the new tag, a short
-  changelog of commits since the previous release, and a working URL
-  to the actual release page
+- Richer Discord release notification. Embeds the new tag, a short
+  changelog of commits since the previous release, and a working URL to
+  the actual release page
 - Added `.github/CODEOWNERS` with `@OpenSource-For-Freedom` as global owner
-- Run `ci.yml` on pull requests to `main`; gate the release job to
-  `main` pushes
+- Run `ci.yml` on pull requests to `main`; gate the release job to `main`
+  pushes
 - Applied least-privilege permissions per job in CI
 - Various GitHub Actions and Rust dependency bumps via Dependabot
 

--- a/README.md
+++ b/README.md
@@ -12,39 +12,112 @@
 	<a href="https://hits.sh/github.com/Security-International-Group/HARDN/"><img src="https://hits.sh/github.com/Security-International-Group/HARDN.svg?style=flat&label=views" alt="views" /></a>
 </p>
 
-HARDN is a security hardening toolkit for Debian-based Linux systems. It automates the lockdown of a fresh install and keeps watching for threats through an integrated set of services.
+HARDN is a security hardening toolkit for Debian-based Linux. It automates the
+lockdown of a fresh install, watches for drift on the files attackers care
+about, and keeps the operator in the loop through a GUI, an API, and a service
+manager.
 
-**Demo Version** - This is a demonstration version showcasing core security features of HARDN-XDR, the full enterprise solution. For production use and advanced features, please contact Security International Group.
-## Key Features
+**Demo Version.** This release demonstrates the core features of HARDN-XDR. For
+production use and advanced features, contact Security International Group.
 
-- **Automated System Hardening** - One-command security configuration
-- **Continuous Security Monitoring** - Real-time threat detection via LEGION daemon
-- **Security Scanner Integration** - Built-in AIDE and custom security tools
-- **Network Protection** - Fail2ban integration with advanced network monitoring
-- **Interactive GUI** - Real-time monitoring dashboard
-- **Service Management** - Easy-to-use command-line service manager
-- **Zero SSH Exposure** - Port 22 is closed by default; remote access is exclusively through Grafana (port 9002) and the HARDN API (port 8000)
+## Features
 
-## Remote Access
+- **Automated hardening.** One-command lockdown of SSH, auditd, sysctl,
+  AppArmor, fail2ban, AIDE and friends.
+- **Environment-aware.** Auto-detects bare-metal, cloud (AWS, GCP, Azure, DO,
+  Oracle, Alibaba), VMs, and containers, then adjusts what it applies so it
+  does not lock you out of a cloud instance or break rootless Podman / Firejail
+  / Chrome sandbox / bpftrace on a container host.
+- **SSH lockout safety.** Will not disable `PasswordAuthentication` on a cloud
+  VM that has no public key registered. Operator overrides via
+  `HARDN_FORCE_DISABLE_PASSWORD_AUTH=1` and `HARDN_KEEP_PASSWORD_AUTH=1`.
+- **SENTRY drift detection.** Daily sha256 baseline diff of high-value files
+  (`/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, `authorized_keys`,
+  `/etc/cron.*`, `/etc/systemd/system/*`). Drift fires an alert with severity
+  scaled to the category.
+- **Alert fanout.** Alerts land in `/var/log/hardn/alerts.jsonl` and fan out to
+  **journald** (always) and an optional **webhook**
+  (`HARDN_ALERT_WEBHOOK_URL`). A TTL-based dedupe cache stops a noisy condition
+  from paging the on-call repeatedly.
+- **Cron safety.** Every scheduled job runs under `flock` so a manual run and
+  the daemon cannot collide. Suricata rule updates land in a staging dir,
+  pass `suricata -T -S` validation, and atomically swap into place via
+  `rename(2)`.
+- **GUI.** GTK4 monitoring dashboard with a first-run welcome wizard, tab
+  tooltips, and an auto-generated inventory of every tool under
+  `usr/share/hardn/tools`. Read-only; never runs privileged commands without
+  a sudo prompt.
+- **API.** Optional REST endpoint on port 8000 with SSH-key bearer auth.
+- **Clean uninstall.** `hardn-uninstall.sh` reverses what the install put
+  in place, including per-user desktop launchers and the
+  `/etc/profile.d/hardn-paths.sh` env-var loader. `apt purge hardn` performs
+  the same cleanup via `debian/postrm`.
 
-> **SSH port 22 is blocked by the HARDN firewall policy. There is no standard SSH remote access.**
+## Quick Start
 
-All remote access to a HARDN-hardened system is restricted to two channels:
+### From source
 
-| Channel | Port | Auth | Purpose |
-|---------|------|------|---------|
-| **Grafana Dashboard** | 9002 | Grafana credentials | Visual monitoring, dashboards, alerting |
-| **HARDN API** | 8000 | SSH public key (Bearer token) | Programmatic control, health queries, diagnostics |
+```bash
+git clone https://github.com/Security-International-Group/HARDN
+cd HARDN
+sudo make build
+sudo make hardn
+```
 
-Before running `ufw.sh`, register your SSH public key so the HARDN API can authenticate you:
+`make build` produces the Debian package. `make hardn` installs it and starts
+the GUI service manager, which is where you trigger the actual hardening run.
+
+### First run
+
+On first launch the GUI shows a four-step Debian-style welcome wizard
+(overview, GUI tour, common actions, where to get help) with **Skip** and
+**Don't show again** options. The marker file is
+`$XDG_CONFIG_HOME/hardn/welcome-seen`; set `HARDN_NO_WELCOME=1` to suppress
+it under kiosk / CI / autostart.
+
+### Common commands
+
+```bash
+sudo hardn --help              # full command list
+sudo hardn --status            # current service state
+sudo hardn --sentry-check      # diff high-value files vs baseline
+sudo hardn run-module hardening
+sudo hardn run-tool   fail2ban
+sudo hardn legion --create-baseline
+sudo hardn-service-manager     # interactive menu (also launched by the GUI)
+```
+
+`run-tool` and `run-module` now return exit 127 (POSIX "command not found")
+when the requested script does not exist, so cron and CI can tell a typo apart
+from a real failure.
+
+## Remote access
+
+HARDN does not block SSH by default. The hardening run tightens sshd
+(public-key auth, no root login, modern ciphers, banner, rate limiting) and
+leaves the service running. UFW allows the configured SSH port; restrict it
+to specific source ranges with `HARDN_SSH_ALLOWED_CIDRS=10.0.0.0/8,...`.
+
+To fully disable SSH, set `HARDN_DISABLE_SSH=1` before the hardening run.
+HARDN will stop, disable, and mask `ssh.service` and `ssh.socket`, and skip
+adding the UFW allow rule.
+
+Two optional remote channels can be exposed in addition to (or instead of)
+SSH:
+
+| Channel | Default port | Auth | Override |
+|---|---|---|---|
+| HARDN API | 8000 | SSH public key (Bearer) | `HARDN_API_PORT`, `HARDN_API_ALLOWED_CIDRS` |
+| Grafana | 3000 | Grafana credentials | `HARDN_GRAFANA_PORT`, `HARDN_GRAFANA_ALLOWED_CIDRS` |
+
+Register a public key with the API:
 
 ```bash
 sudo install -d -m 750 /etc/hardn
 sudo install -m 640 /dev/null /etc/hardn/authorized_keys
 cat ~/.ssh/id_ed25519.pub | sudo tee -a /etc/hardn/authorized_keys
+sudo systemctl restart hardn-api.service
 ```
-
-Then access the API from any remote machine:
 
 ```bash
 SSH_KEY=$(cat ~/.ssh/id_ed25519.pub)
@@ -52,101 +125,87 @@ curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/health
 curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/overwatch/system
 ```
 
-## Quick Start
-
-### From Source
-```bash
-git clone https://github.com/Security-International-Group/HARDN
-cd HARDN
-sudo make build
-sudo make hardn
-```
-- This launches the service manager automatically and builds the Debian package. 
-- To move forward, use the service manager choices to launch the hardening script or other options as needed. 
-
-### HARDN Usage
-
-- Upon using the standard `sudo make hardn` the Security Information and Event Management (SIEM) graphic interface will launch automatically alongside the service manager. 
-- This application provides real-time monitoring of a system's security status and places a local GTK4 Native app within the user's 
-desktop environment.
-
-**SIEM**
-- When you have deployed `hardn` as the native app, and close it, when you click to reopen it all services will be "down" until you choose option (11) start hardn SIEM - and that will restart all services and logging. 
-
-**Service Manager**
-
-- This service manager allows users to manage HARDN services interactively, through both a command line interface (CLI) and the SIEM.
-```bash
-sudo hardn-service-manager
-```
-
-- Users can choose to launch HARDN module scripts or run security tools individually.
-- A security report can be launched based on a built-in HARDN compliance meter aligned to CIS standards (Center for Internet Security).
-- The Service Manager is there to monitor, launch and get the needed system data an administrator needs in times of monitoring and response. 
-
-## What HARDN Does
->[![ci](https://github.com/Security-International-Group/HARDN/actions/workflows/ci.yml/badge.svg)](https://github.com/Security-International-Group/HARDN/actions/workflows/ci.yml)
->[![SAST](https://github.com/Security-International-Group/HARDN/actions/workflows/codeql.yml/badge.svg)](https://github.com/Security-International-Group/HARDN/actions/workflows/codeql.yml)
-
-### Security Hardening
-Applies security configurations to a system with a single command.
-
-### Real-Time Monitoring
-Continuous security monitoring through the LEGION daemon, tracking system changes and potential threats.
-
-### Integrated GUI
-Real-time monitoring dashboard showing system status, security events, and service health.
+See [docs/hardn-api.md](docs/hardn-api.md) for the full endpoint list and key
+rotation guidance.
 
 ## Services
 
-HARDN installs two main services:
+After install, `debian/postinst` enables four systemd units:
 
-### **hardn.service**
-Security hardening service that applies security configurations when triggered.
+| Unit | Purpose |
+|---|---|
+| `hardn.service` | Core hardening + LEGION monitoring loop |
+| `hardn-api.service` | REST API on port 8000 |
+| `hardn-monitor.service` | Service health + alert producer |
+| `hardn-monitor.service` companions | Cron orchestrator runs inside |
 
-### **legion-daemon.service**
-![LEGION](docs/assets/legion.jpeg)
-Continuous security monitoring daemon that watches for threats and system changes.
+`legion-daemon.service` is intentionally not enabled on new installs.
+`hardn.service` runs the same LEGION daemon code; running both at once
+contends on the baseline SQLite database. Operators who want the
+response-disabled variant can swap in `legion-daemon.service` manually.
 
-![Enemy Detection](docs/assets/enemy.jpeg)
+## Environment overrides
 
-## Basic Troubleshooting
+The hardening modules and tools read these in addition to the defaults:
 
-### Check Service Status
+| Variable | Default | Effect |
+|---|---|---|
+| `HARDN_DISABLE_SSH` | `0` | `1` stops + disables + masks `ssh.service` |
+| `HARDN_SSH_PORT` | `22` | Port honoured by fail2ban jail and UFW allow rules |
+| `HARDN_SSH_ALLOWED_CIDRS` | (none) | Space-separated allowlist for SSH |
+| `HARDN_FORCE_DISABLE_PASSWORD_AUTH` | `0` | `1` forces `PasswordAuthentication no` even if no keys exist |
+| `HARDN_KEEP_PASSWORD_AUTH` | `0` | `1` forces `PasswordAuthentication yes` |
+| `HARDN_API_PORT` | `8000` | API listen port |
+| `HARDN_API_ALLOWED_CIDRS` | (none) | Allowlist for the API port |
+| `HARDN_GRAFANA_PORT` | `3000` | Grafana listen port |
+| `HARDN_GRAFANA_ALLOWED_CIDRS` | (none) | Allowlist for the Grafana port |
+| `HARDN_PERMITTED_OUTBOUND_CIDRS` | (none) | Extra outbound destinations to allow in UFW |
+| `HARDN_CLOUD_LB_CIDRS` | provider-specific | Overrides fail2ban `ignoreip` health-check ranges |
+| `HARDN_CONTAINER_HOST` | auto-detected | `1` forces the "container workload host" sysctl profile |
+| `HARDN_STRICT_USERNS` | `0` | `1` applies `kernel.unprivileged_userns_clone=0` even on container hosts |
+| `HARDN_STRICT_BPF` | `0` | `1` applies the eBPF lockdown even on container hosts |
+| `HARDN_KERNEL_PANIC_SECONDS` | `60` | `kernel.panic` value (`0` to stay in panic for diagnosis) |
+| `HARDN_ALERT_WEBHOOK_URL` | (none) | When set, alerts POST to this URL via `curl` |
+| `HARDN_ALERT_JOURNALD_TAG` | `HARDN-ALERT` | syslog tag for journald-bound alerts |
+| `HARDN_ALERT_DEDUPE_TTL_SEC` | `21600` | Dedupe window for journald + webhook fanout |
+| `HARDN_NO_WELCOME` | `0` | `1` suppresses the GUI welcome wizard |
+
+## Basic troubleshooting
+
 ```bash
-sudo systemctl status hardn.service
-sudo systemctl status legion-daemon.service
+sudo systemctl status hardn.service hardn-api.service hardn-monitor.service
+sudo journalctl -u hardn.service -u hardn-monitor.service -f
+tail -F /var/log/hardn/*.log
+tail -F /var/log/hardn/alerts.jsonl
+journalctl -t HARDN-ALERT --since today    # post-PR-C: alert fanout
 ```
 
-### View Logs
-```bash
-sudo journalctl -u hardn.service
-sudo journalctl -u legion-daemon.service
-```
+If a hardening module fails inside an unprivileged container, that is
+expected. The audit subsystem and several sysctls belong to the host kernel;
+HARDN logs those as INFO and continues.
 
 ## Documentation
 
-For detailed technical information, see:
-- [HARDN Service Documentation](docs/hardn.md)
-- [LEGION Daemon Documentation](docs/legion-daemon.md)
-- [HARDN API Documentation](docs/hardn-api.md)
-- [Service Manager Guide](docs/hardn-service-manager.md)
+- [HARDN service](docs/hardn.md)
+- [LEGION daemon](docs/legion-daemon.md)
+- [HARDN API](docs/hardn-api.md)
+- [Service manager guide](docs/hardn-service-manager.md)
+- [Monitor + alert fanout](docs/hardn-monitor.md)
+- [Audit engine internals](docs/hardn-audit.md)
+- [Security posture summary](docs/security-posture.md)
+- [Architecture diagrams](docs/diagram.md)
 
 ## Support
 
-Some modules may fail in restricted environments (containers, read-only filesystems). This is expected behavior - the service will continue running while logging any issues.
-
-## Note
-
-This is a demonstration version with core security features. For enterprise security requirements, please contact Security International Group for the full HARDN solution.
+Some modules will partially apply on read-only filesystems, in containers,
+and on hosts with non-standard package layouts. HARDN logs what it skipped
+and keeps going. Open an issue with the `--security-report --json` output
+attached if behaviour looks wrong.
 
 ## License
 
-MIT License - See LICENSE file for details
-
+MIT. See `LICENSE`.
 
 # Metrics
 
 ![GitHub Metrics](.github/metrics.svg)
-
-

--- a/docs/hardn-api.md
+++ b/docs/hardn-api.md
@@ -3,11 +3,20 @@
 
 ## Purpose
 
-The HARDN API provides comprehensive overwatch and health monitoring for endpoints in distributed environments. It integrates with HARDN security services and the Legion monitoring daemon to enable real-time system monitoring, diagnostics, and management.
+The HARDN API provides overwatch and health monitoring for endpoints in
+distributed environments. It integrates with HARDN security services and
+the Legion monitoring daemon for live system monitoring, diagnostics, and
+management.
 
-> **SSH port 22 is closed on HARDN-hardened systems.** Remote access is restricted to two channels only:
-> - **Grafana dashboard** — port **9002** (visual monitoring)
-> - **HARDN API** — port **8000** (programmatic access, documented here)
+> HARDN's hardening run keeps `ssh.service` running by default and applies
+> a key-only sshd config. To fully close SSH, set `HARDN_DISABLE_SSH=1`
+> before running the hardening module; HARDN will stop, disable, and mask
+> the service. Two optional remote channels are commonly exposed alongside
+> or in place of SSH:
+>
+> - **HARDN API** on port **8000** (programmatic access, documented here)
+> - **Grafana** dashboard on port **3000** (visual monitoring;
+>   override with `HARDN_GRAFANA_PORT`)
 
 This server does not replace the **Grafana** endpoint system, but provides an open-source option for those interested in holistic monitoring within their own toolsets.
 
@@ -25,9 +34,13 @@ cat ~/.ssh/id_ed25519.pub | sudo tee -a /etc/hardn/authorized_keys
 sudo systemctl restart hardn-api.service
 ```
 
-Each line in `/etc/hardn/authorized_keys` holds one SSH public key (same format as `~/.ssh/authorized_keys`). Only keys listed here will be accepted — format-valid but unlisted keys are rejected with HTTP 401.
+Each line in `/etc/hardn/authorized_keys` holds one SSH public key (same
+format as `~/.ssh/authorized_keys`). Only keys listed here will be
+accepted; format-valid but unlisted keys are rejected with HTTP 401.
 
-All API requests (except `GET /health`) require an SSH public key as a Bearer token. The key must be pre-registered in `/etc/hardn/authorized_keys` on the server — see **Setup** above.
+All API requests (except `GET /health`) require an SSH public key as a
+Bearer token. The key must be pre-registered in
+`/etc/hardn/authorized_keys` on the server (see **Setup** above).
 
 ### Generate a Key Pair (client side)
 
@@ -50,33 +63,35 @@ sudo systemctl restart hardn-api.service
 
 ### Transferring a Key from a Remote Machine
 
-Because SSH (port 22) is closed, you cannot use `ssh-copy-id`. You have two practical options depending on whether you still have **temporary SSH access** during initial setup or not:
+If you have set `HARDN_DISABLE_SSH=1` you cannot use `ssh-copy-id`. You
+have two practical options depending on whether you still have
+**temporary SSH access** during initial setup or not:
 
-**Option A — During initial setup (SSH still open)**
+**Option A: during initial setup (SSH still open)**
 
 Use this window before SSH is locked out to push the public key:
 
 ```bash
-# On the CLIENT — copy the public key to the server's tmp directory
+# On the CLIENT, copy the public key to the server's tmp directory
 scp ~/.ssh/hardn_api_key.pub admin@your-server:/tmp/new_key.pub
 
-# On the SERVER — append and secure
+# On the SERVER, append and secure
 sudo tee -a /etc/hardn/authorized_keys < /tmp/new_key.pub
 sudo rm /tmp/new_key.pub
 sudo systemctl restart hardn-api.service
 ```
 
-**Option B — Out-of-band (no SSH, air-gapped or already locked down)**
+**Option B: out-of-band (no SSH, air-gapped or already locked down)**
 
 Physically or via an admin console, paste the public key directly:
 
 ```bash
-# On the client — print the public key to copy it:
+# On the client, print the public key to copy it:
 cat ~/.ssh/hardn_api_key.pub
 # Output looks like:
 # ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... hardn-api
 
-# On the SERVER — paste it in as root:
+# On the SERVER, paste it in as root:
 sudo bash -c 'echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... hardn-api" >> /etc/hardn/authorized_keys'
 sudo systemctl restart hardn-api.service
 ```
@@ -88,7 +103,7 @@ sudo systemctl restart hardn-api.service
 | Only the **public key** (`.pub`) is ever transferred | The private key never leaves the client machine |
 | Use `>>` (append), not `>` (overwrite) | Prevents wiping existing authorized keys |
 | `chmod 600 /etc/hardn/authorized_keys` | Prevents other users from reading or modifying the keystore |
-| Revoke access by removing that key's line from the file | Instant revocation — the private key becomes useless |
+| Revoke access by removing that key's line from the file | Instant revocation. The private key becomes useless |
 
 **Revoking a client key:**
 
@@ -114,7 +129,9 @@ curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/overwatch/syste
 curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/overwatch/services
 ```
 
-> Use `your-server:8000` — **not** `localhost:8000` unless you are on the machine itself. SSH (port 22) is closed; this API is your remote access path.
+> Use `your-server:8000`, **not** `localhost:8000`, unless you are on the
+> machine itself. This API is your remote-access path whenever SSH is
+> disabled or restricted.
 
 ## API Endpoints
 
@@ -138,7 +155,9 @@ curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/overwatch/servi
 
 ## Usage for Remote Servers
 
-> Reminder: SSH (port 22) is closed. Use port **8000** for API access and port **9002** for Grafana.
+> Reminder: when SSH is disabled (`HARDN_DISABLE_SSH=1`), use port
+> **8000** for API access and port **3000** for Grafana
+> (override with `HARDN_GRAFANA_PORT`).
 
 ### Monitoring from a Remote Machine
 

--- a/docs/hardn-audit.md
+++ b/docs/hardn-audit.md
@@ -84,7 +84,10 @@ When adding a new rule:
 
 `rules_source.txt` doubles as the canonical rule list and as documentation for compliance status. Each block provides a human-friendly title, the SCAP/XCCDF rule ID, and the latest evaluation result.
 
-The generator pipeline reads this file and emits `rules_autogen.inc`, preserving ordering and categories. The `Result` column is informational—it does *not* change runtime behaviour—but it is useful when triaging which rules still lack implementations.
+The generator pipeline reads this file and emits `rules_autogen.inc`,
+preserving ordering and categories. The `Result` column is
+informational (it does *not* change runtime behaviour), but it is useful
+when triaging which rules still lack implementations.
 
 ## Rule Lifecycle
 

--- a/docs/hardn-monitor.md
+++ b/docs/hardn-monitor.md
@@ -50,9 +50,38 @@ The monitoring system aggregates log data from multiple sources:
 ### IOC and Error Monitoring
 
 - **Indicators of Compromise (IOC)**: Automated detection and processing of known threat indicators
-- **Error Monitoring**: Comprehensive error tracking across all HARDN components
+- **Error Monitoring**: Per-component error tracking across all HARDN services
 - **Update Monitoring**: Tracking of security updates and system changes
 - **Collective Feed Source**: Unified log aggregation for centralized monitoring
+
+## Alert Channel and Fanout
+
+Every alert producer (`hardn-monitor`, the LEGION daemon, `hardn --sentry-check`)
+writes one JSON-lines record into `/var/log/hardn/alerts.jsonl`:
+
+```json
+{"ts":"2026-05-25T18:30:42Z","severity":"critical","source":"sentry/sudoers","message":"sudoers added watched file: /etc/sudoers.d/badop","key":"sentry:sudoers:added:/etc/sudoers.d/badop"}
+```
+
+Fields are fixed: `ts`, `severity`, `source`, `message`, `key`. Severities
+used today: `info`, `warning`, `error`, `critical`.
+
+`alerts.jsonl` is the canonical record. After writing, each alert is
+forwarded to two optional sinks gated by a shared TTL dedupe so a noisy
+condition cannot pager-spam:
+
+| Sink | Mechanism | Enable by |
+|---|---|---|
+| journald | `systemd-cat -t HARDN-ALERT -p <prio>` (fallback `logger(1)`) | Always on |
+| Webhook | `curl -fsS -m 10 -X POST` with the JSON payload as body | Set `HARDN_ALERT_WEBHOOK_URL=https://...` |
+
+Dedupe state lives at `/var/lib/hardn/alerts/seen.json`, keyed by the
+`key` field. Default TTL is 21600 s (6 hours); override via
+`HARDN_ALERT_DEDUPE_TTL_SEC`. The journald tag and dedupe path can be
+overridden with `HARDN_ALERT_JOURNALD_TAG` and `HARDN_ALERT_DEDUPE_PATH`.
+
+The GUI tails `alerts.jsonl` and collapses repeats of the same `key` into
+a single updating row.
 
 ## Usage
 
@@ -122,7 +151,7 @@ sudo hardn legion
 - **Threat Detection**: Automated threat intelligence processing
 - **Anomaly Detection**: Network and system behavior analysis
 - **Incident Response**: Automated response capabilities
-- **Audit Logging**: Comprehensive security event logging
+- **Audit Logging**: Auditd rules cover MITRE ATT&CK T1003/T1041/T1053/T1059/T1105/T1547/T1562, paired across `arch=b64` and `arch=b32` so 32-bit compat syscalls cannot evade. Audit buffer size and disk-full action scale to free space on `/var/log`.
 
 ## Troubleshooting
 

--- a/docs/hardn-service-manager.md
+++ b/docs/hardn-service-manager.md
@@ -49,7 +49,7 @@ The service manager addresses the complexity of managing multiple security compo
 
 ### System Operations
 - Security report generation
-- Comprehensive status display
+- Full status display
 - Sandbox mode (network isolation)
 - Run everything (modules + tools combined)
 
@@ -125,7 +125,7 @@ Main Menu
 - Sandbox mode warns about network disconnection
 
 ### Error Handling
-- Comprehensive error checking
+- Per-action error checking
 - Graceful failure handling
 - User-friendly error messages
 

--- a/docs/hardn-service.md
+++ b/docs/hardn-service.md
@@ -5,8 +5,8 @@
 graph TD
 
 %% ===================== ENTRYPOINTS =====================
-U["User / Admin (Remote)"] -->|"HARDN API — port 8000 (SSH key auth)"| API[HARDN API Service]
-U -->|"Grafana Dashboard — port 9002"| GRF[Grafana]
+U["User / Admin (Remote)"] -->|"HARDN API: port 8000, SSH key auth"| API[HARDN API Service]
+U -->|"Grafana Dashboard: port 3000"| GRF[Grafana]
 CLI[hardn CLI] -->|manual execution| CORE[HARDN Core Service]
 API -->|remote trigger| CORE
 GRF -->|datasource queries| API
@@ -103,7 +103,7 @@ class SYSMD,JRN,CRN,NETM os
 | Component | Role |
 |------------|------|
 | **HARDN Core Service** | Executes system-wide security hardening modules and configuration routines. |
-| **HARDN API Service** | REST API on port **8000** — the only programmatic remote access channel. SSH key auth required. Port 22 (SSH) is closed. |
+| **HARDN API Service** | REST API on port **8000**. SSH key auth required. The default sshd is hardened (key-only) but left running; set `HARDN_DISABLE_SSH=1` to fully close it, in which case the API is the primary remote channel. |
 | **Hardening Modules** | Individual system-hardening scripts enforcing STIG/CIS standards. |
 | **Security Tools Layer** | Integrates AppArmor, Fail2Ban, UFW, Auditd, ClamAV, rkhunter, and AIDE under one orchestration layer. |
 | **Audit & Compliance Engine** | Ensures continuous monitoring and reporting against NIST/STIG benchmarks. |

--- a/docs/hardn.md
+++ b/docs/hardn.md
@@ -1,199 +1,255 @@
 ![HARDN Logo](assets/IMG_1233.jpeg)
-# HARDN - Linux Security Hardening & Extended Detection Response Package
+# HARDN, Linux Security Hardening and Extended Detection Response
 
 ## Overview
 
-HARDN is an open-source security hardening and threat detection toolkit for Debian-based Linux. It automates the security configuration process, runs continuous background monitoring via the LEGION daemon, and gives operators a single place to manage it all.
+HARDN is an open-source security hardening and threat-detection toolkit for
+Debian-based Linux. It automates the security-configuration process, runs
+continuous background monitoring through the LEGION daemon, and gives
+operators a single place to manage it all.
 
 ## What HARDN Is
 
-HARDN is a complete security framework that includes:
+### Core security components
 
-### Core Security Components
-- **Automated Hardening**: STIG-compliant security configuration and hardening scripts
-- **Threat Detection**: Anomaly detection and threat intelligence integration
-- **Service Management**: Systemd service orchestration and monitoring
-- **API Integration**: RESTful API for remote monitoring and management
-- **Interactive Interface**: Service manager with real-time monitoring
+- **Automated hardening**: STIG- and CIS-leaning hardening scripts that lock
+  down SSH, auditd, sysctl, kernel modules, AppArmor, fail2ban, and friends.
+- **Environment-aware**: auto-detects bare-metal, cloud (AWS, GCP, Azure,
+  DigitalOcean, Oracle, Alibaba), VMs, and containers, then adjusts which
+  steps it applies. Containers skip module ops; cloud VMs keep IPv6 SLAAC
+  intact; container hosts keep `unprivileged_userns_clone` at the kernel
+  default so rootless workloads keep working.
+- **SENTRY drift detection**: a sha256 baseline diff of high-value files
+  (`/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, `authorized_keys`,
+  `/etc/cron.*`, `/etc/systemd/system/*`). Drift fires one alert per
+  added, removed, or changed entry.
+- **Alert fanout**: alerts land in `/var/log/hardn/alerts.jsonl` and also
+  fan out to journald (always) and an optional webhook (set
+  `HARDN_ALERT_WEBHOOK_URL`). Shared TTL dedupe stops repeat alerts from
+  paging the on-call.
+- **Cron safety**: every scheduled job runs under `flock` so a manual run
+  and the daemon cannot collide. Suricata rule updates stage, validate,
+  then atomically swap into place.
+- **Service management**: systemd service orchestration and monitoring.
+- **REST API**: optional HTTP endpoint for remote monitoring and management.
+- **Interactive interface**: service manager with live status display.
 
-### Security Monitoring Features
-- **LEGION Daemon**: Continuous security monitoring with syslog, journal, and network analysis
-- **IOC Processing**: Indicators of Compromise detection and automated response
-- **Service Health Monitoring**: Real-time status monitoring of all security services
-- **Log Aggregation**: Centralized logging and alerting across all components
+### Monitoring features
 
-### Management Tools
-- **Interactive Service Manager**: Menu-driven interface for complete system control
-- **Command-Line Interface**: Full CLI for automation and scripting
-- **REST API**: Programmatic access for integration with other security tools
-- **Package Management**: Automated installation and configuration
+- **LEGION daemon**: continuous monitoring across syslog, the systemd
+  journal, network metrics, and process telemetry.
+- **IOC processing**: indicator-of-compromise detection and automated
+  response.
+- **Service health monitoring**: live status of every HARDN service.
+- **Log aggregation**: alerts.jsonl plus journald is the single channel.
+
+### Management tools
+
+- **Interactive service manager**: menu-driven control of services,
+  modules, tools, and reports.
+- **Command-line interface**: full CLI for automation and scripting.
+- **REST API**: programmatic access for integration with other security
+  tools.
+- **GTK4 GUI**: first-run welcome wizard, tab tooltips, tool inventory,
+  read-only log and alert view.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    HARDN Security Framework                 │
-├─────────────────────────────────────────────────────────────┤
-│   ┌─────────────┐  ┌─────────────┐  ┌─────────────┐         │
-│   │ Service     │  │ LEGION      │  │ REST API    │         │
-│   │ Manager     │  │ Daemon      │  │ Service     │         │
-│   │ (Interactive│  │ (Monitoring)│  │ (Remote     │         │
-│   │ Interface)  │  │             │  │ Access)     │         │
-│   └─────────────┘  └─────────────┘  └─────────────┘         │
-├─────────────────────────────────────────────────────────────┤
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
-│  │ Hardening   │  │ Threat      │  │ System      │          │
-│  │ Scripts     │  │ Intelligence│  │ Monitoring  │          │
-│  │             │  │             │  │             │          │
-│  └─────────────┘  └─────────────┘  └─────────────┘          │
-├─────────────────────────────────────────────────────────────┤
-│                 Debian Linux System                         │
-└─────────────────────────────────────────────────────────────┘
++-----------------------------------------------------------+
+|                    HARDN Security Framework               |
++-----------------------------------------------------------+
+|   +-------------+  +-------------+  +-------------+       |
+|   | Service     |  | LEGION      |  | REST API    |       |
+|   | Manager     |  | Daemon      |  | Service     |       |
+|   | (Interactive|  | (Monitoring)|  | (Remote     |       |
+|   | Interface)  |  |             |  | Access)     |       |
+|   +-------------+  +-------------+  +-------------+       |
++-----------------------------------------------------------+
+|  +-------------+  +-------------+  +-------------+        |
+|  | Hardening   |  | Threat      |  | System      |        |
+|  | Scripts     |  | Intelligence|  | Monitoring  |        |
+|  +-------------+  +-------------+  +-------------+        |
++-----------------------------------------------------------+
+|                 Debian Linux System                       |
++-----------------------------------------------------------+
 ```
 
 ## Key Features
 
-### Security Hardening
-- **STIG Compliance**: Automated implementation of Security Technical Implementation Guides
-- **CIS Benchmarks**: Center for Internet Security benchmark compliance
-- **Package Hardening**: Secure configuration of installed packages
-- **Network Security**: Firewall configuration and network hardening
+### Hardening
 
-### Threat Detection & Response
-- **Real-time Monitoring**: Continuous system and network monitoring
-- **Anomaly Detection**: Behavioral analysis against a stored baseline
-- **IOC Integration**: Automated processing of threat intelligence feeds
-- **Incident Response**: Automated response to detected threats
+- STIG-leaning baseline (PAM, login.defs, sudoers, journald, rsyslog,
+  modprobe, sysctl).
+- Network hardening: UFW + iptables `HARDN-LOCKDOWN` chain. Cloud
+  metadata IPs are allowlisted on cloud hosts.
+- Filesystem and mount hygiene: `fs.protected_*`, world-writable audit,
+  file-permission table for `/etc/{passwd,shadow,sudoers,*}`.
 
-### Service Management
-- **Systemd Integration**: Complete service lifecycle management
-- **Dependency Management**: Automatic handling of service dependencies
-- **Health Monitoring**: Continuous service health checks
-- **Failover Support**: Automatic service restart and recovery
+### Detection and response
 
-### User Interface
-- **Interactive Console**: Menu-driven interface for system administration
-- **Web Dashboard**: Browser-based monitoring and management (planned)
-- **API Access**: RESTful API for programmatic control
-- **CLI Tools**: Command-line utilities for automation
+- Live monitoring of system and network state.
+- Behavioural analysis against a stored baseline (SQLite-backed under
+  `/var/lib/hardn/legion/`).
+- Indicator-of-compromise processing from threat-intelligence feeds.
+- Automated response gated behind `response_enabled`.
+- SENTRY daily file-drift diff, fed into the unified alert channel.
+
+### Service management
+
+- Full lifecycle through `systemctl` and `hardn-service-manager`.
+- Service dependencies handled by `systemd`.
+- Service health monitoring through `hardn-monitor.service`.
+- Service restart and recovery via `Restart=on-failure` in unit files.
+
+### Interfaces
+
+- Interactive console (`hardn-service-manager`).
+- GTK4 desktop GUI (`hardn-gui`).
+- REST API on port 8000 (key-based bearer auth).
+- CLI subcommands (`hardn --help`).
 
 ## Quick Start
 
-### Installation & Setup
+### Install and launch
 
 ```bash
-# Clone the repository
 git clone https://github.com/Security-International-Group/HARDN.git
 cd HARDN
-
-# Build and install
 sudo make build
 sudo make hardn
-
-# Launch the interactive service manager
-sudo make hardn
 ```
 
-### Basic Usage
+`make build` produces the Debian package; `make hardn` installs it and
+opens the service manager and the GUI.
+
+### Basic usage
 
 ```bash
-# Check system status
-sudo hardn --status
-
-# Run security assessment
-sudo hardn --security-report
-
-# View help
-hardn --help
+sudo hardn --help              # full command list
+sudo hardn --status            # current service state
+sudo hardn --security-report   # one-shot security assessment
+sudo hardn --sentry-check      # SENTRY file-drift diff
+sudo hardn run-module hardening
+sudo hardn run-tool   fail2ban
+sudo hardn legion --create-baseline
 ```
+
+`run-module` and `run-tool` return exit 127 when the script does not exist
+(POSIX "command not found"), so cron and CI can tell a typo from a real
+failure.
 
 ## Components
 
-### HARDN Service Manager
-The primary interface for managing all HARDN components. Provides:
-- Interactive menus for service control
-- Real-time monitoring dashboards
+### HARDN service manager
+
+Primary interactive interface. Provides:
+
+- Menu-driven service control
+- Live status dashboards
 - Log viewing and analysis
 - Configuration management
 
-### LEGION Security Daemon
-Continuous monitoring daemon that provides:
+### LEGION security daemon
+
+Continuous monitoring with:
+
 - System log analysis
 - Network traffic monitoring
-- Threat intelligence processing
+- Threat-intelligence processing
 - Automated incident response
+- SENTRY file-baseline drift detection
 
-### HARDN API Service
-RESTful API for remote management and monitoring:
+### HARDN API service
+
+REST API for remote management and monitoring:
+
 - System health metrics
-- Service status monitoring
-- Remote command execution
+- Service status
+- Remote command execution (limited command set)
 - Integration with external tools
 
-### Hardening Modules
-Automated security configuration modules:
-- System hardening scripts
-- Package security configuration
-- Network security setup
-- Compliance automation
+### Hardening modules
+
+Automated security-configuration modules under
+`/usr/share/hardn/modules/`. The orchestrator delegates auditd-specific
+rule loading to `/usr/share/hardn/tools/auditd.sh` so there is one writer
+per rule file.
 
 ## Security Benefits
 
-### Proactive Protection
-- **Continuous Monitoring**: 24/7 system surveillance
-- **Threat Intelligence**: Integration with threat feeds
-- **Automated Response**: Automated action on detected threats
-- **Compliance Automation**: Maintain security standards automatically
+### Proactive protection
 
-### Operational Security
-- **Access Control**: SSH key-based authentication
-- **Audit Logging**: Security event logging
-- **Integrity Monitoring**: File and system integrity checks
-- **Network Security**: Firewall and intrusion detection
+- 24/7 system surveillance through `hardn.service`.
+- Threat-intelligence feed integration.
+- Automated response to detected threats.
+- SENTRY baseline-diff catches persistence-vector tampering between
+  scheduled scans.
 
-### Incident Response
-- **Real-time Alerts**: Immediate notification of security events
-- **Automated Mitigation**: Self-healing security responses
-- **Forensic Analysis**: Detailed incident investigation tools
-- **Recovery Automation**: Streamlined system recovery procedures
+### Operational security
 
-## Community & Support
+- SSH key-based authentication (with lockout-safety fallback on cloud).
+- Audit logging tuned for the available `/var/log` space.
+- File and system integrity checks (AIDE).
+- UFW + iptables firewall posture with cloud-metadata carve-outs.
 
-### Who We Are
-HARDN is developed by the **Security International Group (SIG)**, a community-driven organization focused on advancing cybersecurity through open-source solutions.
+### Incident response
 
-### Getting Help
-- **Documentation**: Guides and API references
-- **Issue Tracking**: GitHub issues for bug reports and feature requests
-- **Contributing**: Open contribution guidelines for community involvement
+- Alerts in `/var/log/hardn/alerts.jsonl` plus journald plus optional
+  webhook.
+- Per-key TTL dedupe so a noisy condition does not spam.
+- Self-healing service restart through systemd.
+- Forensic data preserved in `/var/lib/hardn/`.
+
+## Community and Support
+
+### Who we are
+
+HARDN is developed by **Security International Group (SIG)**, a
+community-driven organisation focused on advancing cybersecurity through
+open-source solutions.
+
+### Getting help
+
+- Documentation: guides and API references under `docs/`.
+- Issue tracking: GitHub issues for bug reports and feature requests.
+- Contributing: open contribution guidelines under `CONTRIBUTING.md`.
 
 ### Resources
-- [HARDN Service Manager Documentation](hardn-service-manager.md)
-- [LEGION Daemon Documentation](legion-daemon.md)
-- [HARDN API Documentation](hardn-api.md)
-- [HARDN Monitor Documentation](hardn-monitor.md)
 
-## License & Contributing
+- [Service manager guide](hardn-service-manager.md)
+- [LEGION daemon](legion-daemon.md)
+- [HARDN API](hardn-api.md)
+- [Monitor and alert fanout](hardn-monitor.md)
+- [Audit engine internals](hardn-audit.md)
+- [Security posture summary](security-posture.md)
 
-HARDN is released under the MIT License, encouraging community contributions and commercial use. We welcome contributions from security researchers, developers, and system administrators to help improve and expand the platform.
+## License and Contributing
+
+HARDN is released under the MIT License, encouraging community
+contributions and commercial use. Contributions from security researchers,
+developers, and system administrators are welcome.
 
 ## Roadmap
 
-### Current Version
+### Current
+
 - Interactive service manager
 - LEGION security daemon
 - REST API service
 - Automated hardening scripts
-- Real-time monitoring
+- SENTRY file-baseline drift detection
+- Alert fanout to journald + webhook
+- Environment-aware hardening for cloud, VM, and container surfaces
 
-### Upcoming Features
+### Upcoming
+
 - Web-based dashboard
 - Expanded threat intelligence
 - Multi-system management
-- Remote alerting
+- Additional SENTRY watch sources (AIDE results, package lists)
 
 ---
 
 **Website**: [Security International Group](https://securityinternationalgroup.org)
 **Repository**: [GitHub](https://github.com/Security-International-Group/HARDN)
-**Documentation**: [Full Documentation](https://docs.hardn.security)

--- a/docs/legion-daemon.md
+++ b/docs/legion-daemon.md
@@ -129,9 +129,35 @@ class SYSMD,JRN,NETM,CRON os
 | **Analysis Layer** | Pure-Rust heuristic, signature, and ML-based anomaly detection engines operate on immutable telemetry batches. |
 | **Response Layer** | Applies deterministic policy rules (alert, isolate, block) with cooldown and audit guarantees. |
 | **Baseline Manager** | Handles baseline comparison and update cycles; persists all states in **SQLite** under `/var/lib/hardn/legion/legion.db`. |
-| **SQLite Baseline DB** | The heuristics backbone — stores normalized telemetry, learned baselines, historical risk scores, and ML training data. |
+| **SQLite Baseline DB** | The heuristics backbone. Stores normalized telemetry, learned baselines, historical risk scores, and ML training data. |
 | **Machine Learning Engine** | Uses SQLite data to train, cluster, and evaluate anomaly patterns in real-time. |
 | **Logging & Alerts** | Unified journal logging and structured alert output via `systemd-journal`. |
 | **Integration Services** | systemd, journald, cron, and NetworkManager used for lifecycle, logging, and telemetry scheduling. |
+
+### SENTRY: file-baseline drift detector
+
+`legion::modules::sentry` is a separate, lightweight detector that runs
+once-per-day from the cron orchestrator (`hardn-sentry` at 02:15) and
+also on demand via `sudo hardn --sentry-check`. It is intentionally
+decoupled from the main LEGION pipeline so it cannot crash the daemon and
+can be executed by an operator at any time (for example, after a
+legitimate sysadmin change to capture a fresh baseline).
+
+Watch list (sha256 each present file, diff vs
+`/var/lib/hardn/sentry/baseline.json`):
+
+| Category | Severity on drift | Paths |
+|---|---|---|
+| `authorized_keys` | `critical` | `/root/.ssh/authorized_keys{,2}`, `/home/*/.ssh/authorized_keys{,2}` |
+| `sudoers` | `critical` | `/etc/sudoers`, `/etc/sudoers.d/*` |
+| `passwd_shadow` | `warning` | `/etc/passwd`, `/etc/shadow`, `/etc/gshadow`, `/etc/group` |
+| `cron` | `warning` | `/etc/crontab`, `/etc/cron.{d,daily,hourly,weekly,monthly}/*`, `/var/spool/cron/{,crontabs/}*` |
+| `systemd` | `warning` | `/etc/systemd/system/*.{service,timer,socket,path}`, `/etc/systemd/system/*.d/*.conf` |
+
+First run silently writes the baseline; later runs alert per added,
+removed, or changed entry and refresh the baseline atomically via
+`rename(2)`. Alerts land in `/var/log/hardn/alerts.jsonl` and fan out
+through the shared journald + webhook sinks (see
+[hardn-monitor.md](hardn-monitor.md)).
 
 ---

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -36,15 +36,69 @@ This document provides a consolidated view of the security controls implemented 
 - **Baseline Drift Detection**: Legion compares current processes and listening ports against stored baselines, summarizing additions and missing entries in reports and snapshots.
 - **Risk Scoring Engine**: Component-level factors recorded for anomaly, threat intel, behavioral, network, process, file integrity, system health, and temporal trends. Reports render explanations alongside numeric scores for transparency.
 - **Domain-Aware Script Scoring**: Aggregates script results per domain, elevating anomaly scores when hardening checks emit warnings/failures.
-- **Security Platform Health**: Tracks Grafana, Wazuh, and other platform services—records warnings, inactive states, and time of last alert.
+- **Security Platform Health**: Tracks Grafana, Wazuh, and other platform services. Records warnings, inactive states, and time of last alert.
 - **HIDS Resilience**: OSSEC tooling now auto-falls back to Wazuh packages when the legacy `ossec-hids` feed is unavailable and sends status logs to stderr so automation can detect failures cleanly.
+
+### Environment-aware Hardening
+
+- A pre-flight detector (`tools/env-detect.sh`) classifies the host as
+  bare-metal, VM, container, or cloud (AWS, GCP, Azure, DigitalOcean,
+  Oracle, Alibaba) before any rule is applied. The result is printed as a
+  one-line banner at the start of every hardening run.
+- Cloud and VM hosts retain `accept_ra` so IPv6 SLAAC keeps working.
+- Container workload hosts (Docker, Podman, LXD, k8s state present, or
+  `HARDN_CONTAINER_HOST=1`) skip `unprivileged_userns_clone=0`,
+  `unprivileged_bpf_disabled=1`, and `bpf_jit_harden=2` so rootless
+  workloads (Podman, Firejail, Chrome sandbox, bpftrace, Cilium) continue
+  to function. Operators can force the strict values back on with
+  `HARDN_STRICT_USERNS=1` and `HARDN_STRICT_BPF=1`.
+- The cloud metadata IP (169.254.169.254, plus 168.63.129.16 on Azure) is
+  explicitly allowlisted in UFW and the iptables `HARDN-LOCKDOWN` chain
+  on cloud hosts.
+- SSH hardening will not flip `PasswordAuthentication` to `no` when no
+  public keys exist on a cloud or VM host (prevents permanent remote
+  lockout). Overrides: `HARDN_FORCE_DISABLE_PASSWORD_AUTH=1`,
+  `HARDN_KEEP_PASSWORD_AUTH=1`.
+
+### Audit Rules
+
+- Single writer: `/etc/audit/rules.d/99-hardn-hardening.rules` is owned by
+  `tools/auditd.sh`. The previous duplicate writer in
+  `modules/hardening.sh` has been removed.
+- Buffer size and `disk_full_action` scale to free space on `/var/log`.
+  Small cloud root disks degrade to `SYSLOG` instead of halting the kernel.
+- All execve and module-load rules are paired across `arch=b64` and
+  `arch=b32`, so 32-bit compat syscalls cannot evade.
+- Auditd setup exits cleanly inside containers (audit subsystem belongs
+  to the host kernel).
+
+### File-Baseline Drift (SENTRY)
+
+- Daily sha256 baseline diff of the high-value persistence files:
+  `/etc/passwd`, `/etc/shadow`, `/etc/sudoers{,.d/*}`,
+  `authorized_keys` for root and every UID >= 1000, `/etc/crontab`,
+  `/etc/cron.*`, `/var/spool/cron/*`, `/etc/systemd/system/*.{service,timer,socket,path}`.
+- Added/removed/changed files fire one alert each. Sudoers and
+  authorized_keys drift = `critical`; other categories = `warning`.
+- Alerts share the dedupe + journald + webhook fanout (see Reporting &
+  Response).
 
 ### Reporting & Response
 
-- Enhanced report output includes component factor tables, contributing factors, threat indicator breakdowns, detected issues, and baseline drift summary.
+- Enhanced report output includes component factor tables, contributing
+  factors, threat indicator breakdowns, detected issues, and baseline
+  drift summary.
 - JSON mode mirrors the console output for machine ingestion.
-- Reactive response plans classify suspicious processes (Malicious/Suspicious/Unknown) and recommend block/quarantine/monitor actions with severity and rationale.
-- Automated response engine remains gated behind `response_enabled`; manual review encouraged when disabled.
+- Reactive response plans classify suspicious processes (Malicious /
+  Suspicious / Unknown) and recommend block / quarantine / monitor actions
+  with severity and rationale.
+- Automated response engine remains gated behind `response_enabled`;
+  manual review encouraged when disabled.
+- Unified alert channel: `emit_alert()` writes to
+  `/var/log/hardn/alerts.jsonl` and fans out to journald (always) and an
+  optional webhook (`HARDN_ALERT_WEBHOOK_URL`). Per-key TTL dedupe
+  (default 6 h, override `HARDN_ALERT_DEDUPE_TTL_SEC`) prevents
+  pager-spam.
 
 ## Operational Considerations
 


### PR DESCRIPTION
## Summary

Brings README, CHANGELOG, and seven docs files in line with the six PRs that
landed this session (A-B cloud/VM/container, D tools hygiene, C LEGION
sentry + sinks, E GUI wizard + uninstall, F kernel rules). Also a style
scrub.

### Substantive corrections (not just polish)

| File | Fix |
|---|---|
| README.md | "Port 22 is closed by default" was wrong. The hardening run leaves `ssh.service` running with a key-only sshd config by default; `HARDN_DISABLE_SSH=1` is the toggle. |
| README.md | Grafana port: 3000 (not 9002). |
| README.md | Services list: four units (`hardn`, `hardn-api`, `hardn-monitor`, plus the legion-daemon migration note), not two. |
| README.md | New Environment overrides table for every `HARDN_*` env var operators will set. |
| README.md | New Features section covering env-detect, SENTRY, alert fanout, cron flock, atomic Suricata, welcome wizard. |
| docs/hardn-api.md | Same SSH and Grafana corrections. |
| docs/hardn-service.md | Same SSH correction. |
| docs/legion-daemon.md | New SENTRY drift-detector section with watch list, severities, schedule. |
| docs/hardn-monitor.md | New "Alert Channel and Fanout" section: alerts.jsonl schema, journald + webhook sinks, dedupe semantics. |
| docs/security-posture.md | New sections: Environment-aware Hardening, Audit Rules, SENTRY. |
| docs/hardn.md | Refreshed feature/CLI examples to include `--sentry-check`, EXIT_NOT_FOUND, and the current service set. |
| CHANGELOG.md | [Unreleased] reorganised by PR letter (A+B / D / C / E / F) with what each one actually changed. |

### Style scrub (per request)

- **Em-dashes (—): all removed.** Previous count: 32 (CHANGELOG 14,
  hardn-api 12, hardn-service 3, audit/legion/security-posture 1 each).
  New count across every touched file: **0**.
- **AI-tell adjectives**: dropped "comprehensive" from
  hardn-api / hardn-monitor / hardn-service-manager where it was doing no
  work.
- **No "claude", "anthropic", "copilot", or "openai" strings** in any
  modified file.

### Verification

```text
grep -c '—' across touched .md files          = 0
grep -ciE 'comprehensive|seamless|robust|delve|leverage|...' = 0
git diff --stat                                = 663 insertions, 414 deletions, 10 files
```

## Test plan

- [x] Em-dash and AI-tell scans return zero hits
- [x] No AI-vendor strings in any modified file
- [ ] CI passes (docs-only change; no code touched)
- [ ] README renders cleanly on github.com (table alignment, badge images)
- [ ] CHANGELOG anchor links from past releases still resolve

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_