### PR TITLE
Observability: /metrics endpoint, Prometheus tool, Grafana data source (PR-G)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The unreleased work landed as six stacked PRs (A, B, D, C, E, F) on the
-`patch` branch through May 2026. They are grouped here by area rather than
-by PR.
+The unreleased work landed as seven stacked PRs (A, B, D, C, E, F, G) on
+the `patch` branch through May 2026. They are grouped here by area rather
+than by PR.
+
+### Observability: Prometheus + Grafana wired through (PR G)
+
+- New **`GET /metrics`** endpoint on `hardn-api`, Prometheus text-format,
+  unauthenticated (same access-control story as `/health`: rely on the
+  network-layer policy that UFW + the iptables `HARDN-LOCKDOWN` chain
+  already enforce). Exposed series:
+  - `hardn_info{version=...}`
+  - `hardn_service_up{service=...}` for the four HARDN units
+  - `hardn_alerts_total{severity=...}` from `alerts.jsonl`
+  - `hardn_sentry_drift_total{verb=...,category=...}` from SENTRY records
+  - `hardn_cron_last_run_timestamp_seconds{job=...}`,
+    `hardn_cron_last_success{job=...}`,
+    `hardn_cron_last_duration_seconds{job=...}` from `cron_summary.json`
+  - `hardn_sentry_baseline_age_seconds`
+  - `hardn_legion_baseline_present`
+- New `tools/prometheus.sh`. Installs `prometheus` +
+  `prometheus-node-exporter` from Debian main, appends a
+  `scrape_config_files: /etc/prometheus/prometheus.d/*.yml` include to the
+  shipped `/etc/prometheus/prometheus.yml`, drops a HARDN scrape
+  drop-in that pulls from `localhost:8000/metrics` and the node exporter.
+  Skips on unprivileged containers.
+- `tools/grafana.sh` now honours `HARDN_GRAFANA_PORT` (default 3000) end
+  to end. Previously it hard-coded 9002, which mismatched the UFW rule
+  written by `modules/hardening.sh`. The firewall and the daemon now
+  agree.
+- `tools/grafana.sh` provisions a default **HARDN Prometheus** data
+  source at `/etc/grafana/provisioning/datasources/hardn-prometheus.yaml`,
+  pointed at `$HARDN_PROMETHEUS_URL` (default `http://localhost:9090`).
+  Grafana lights up with data as soon as `tools/prometheus.sh` has run.
+- New env knobs:
+  `HARDN_PROMETHEUS_PORT` (9090),
+  `HARDN_NODE_EXPORTER_PORT` (9100),
+  `HARDN_PROMETHEUS_ALLOWED_CIDRS`,
+  `HARDN_PROMETHEUS_URL`.
+- Misleading placeholder removed. The Rust `"System Monitoring"`
+  category in `src/main.rs` and `src/setup/main.rs` listed
+  `prometheus_monitoring`, which was a string with no backing tool. It is
+  now `["audit", "auditd", "prometheus", "grafana"]`, all of which exist
+  on disk under `usr/share/hardn/tools/`.
 
 ### Hardware, cloud, and container compatibility (PR A + B)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ production use and advanced features, contact Security International Group.
   `usr/share/hardn/tools`. Read-only; never runs privileged commands without
   a sudo prompt.
 - **API.** Optional REST endpoint on port 8000 with SSH-key bearer auth.
+  Unauthenticated `/metrics` endpoint exposes Prometheus-format telemetry
+  (service health, alert counts, SENTRY drift, cron job state, baseline
+  age) for the included `tools/prometheus.sh` + `tools/grafana.sh` stack.
 - **Clean uninstall.** `hardn-uninstall.sh` reverses what the install put
   in place, including per-user desktop launchers and the
   `/etc/profile.d/hardn-paths.sh` env-var loader. `apt purge hardn` performs
@@ -169,6 +172,10 @@ The hardening modules and tools read these in addition to the defaults:
 | `HARDN_ALERT_JOURNALD_TAG` | `HARDN-ALERT` | syslog tag for journald-bound alerts |
 | `HARDN_ALERT_DEDUPE_TTL_SEC` | `21600` | Dedupe window for journald + webhook fanout |
 | `HARDN_NO_WELCOME` | `0` | `1` suppresses the GUI welcome wizard |
+| `HARDN_PROMETHEUS_PORT` | `9090` | Prometheus listen port |
+| `HARDN_PROMETHEUS_URL` | `http://localhost:9090` | URL Grafana provisions as the default data source |
+| `HARDN_PROMETHEUS_ALLOWED_CIDRS` | (none) | Allowlist for the Prometheus port |
+| `HARDN_NODE_EXPORTER_PORT` | `9100` | Prometheus node-exporter scrape target |
 
 ## Basic troubleshooting
 

--- a/docs/hardn-api.md
+++ b/docs/hardn-api.md
@@ -138,6 +138,16 @@ curl -H "Authorization: Bearer $SSH_KEY" http://your-server:8000/overwatch/servi
 ### Health Check
 - `GET /health` - Basic API health check (no authentication required)
 
+### Prometheus metrics
+- `GET /metrics` - Prometheus text-format exposition of HARDN telemetry.
+  Unauthenticated; same access-control posture as `/health` (rely on the
+  UFW + iptables `HARDN-LOCKDOWN` chain to scope who can reach the API
+  port). Series exposed include `hardn_service_up`, `hardn_alerts_total`,
+  `hardn_sentry_drift_total`, `hardn_cron_last_run_timestamp_seconds`,
+  `hardn_sentry_baseline_age_seconds`, and `hardn_legion_baseline_present`.
+  Scrape from `localhost:8000/metrics`; `tools/prometheus.sh` writes a
+  drop-in that does this automatically.
+
 ### Overwatch Monitoring
 - `GET /overwatch/system` - Complete system health metrics (CPU, memory, disk, network)
 - `GET /overwatch/services` - Status of all monitored services

--- a/src/hardn-api.py
+++ b/src/hardn-api.py
@@ -27,7 +27,7 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
-# CORS — restrict to explicit list; override via HARDN_API_CORS_ORIGINS (comma-separated)
+# CORS: restrict to an explicit list; override via HARDN_API_CORS_ORIGINS (comma-separated)
 _raw_origins = os.environ.get(
     "HARDN_API_CORS_ORIGINS", "http://localhost:9002,http://127.0.0.1:9002"
 )
@@ -76,7 +76,7 @@ def verify_ssh_key(credentials: HTTPAuthorizationCredentials = Depends(security)
     if not os.path.isfile(AUTHORIZED_KEYS_FILE):
         logger.error("Authorized keys file not found: %s", AUTHORIZED_KEYS_FILE)
         raise HTTPException(
-            status_code=503, detail="Authorization unavailable — keys file missing"
+            status_code=503, detail="Authorization unavailable: keys file missing"
         )
 
     # Extract the key material (type + base64 blob, ignore optional comment)
@@ -114,7 +114,7 @@ def _safe_net_connections() -> Optional[int]:
 
 # System monitoring functions
 def get_system_health() -> Dict:
-    """Get comprehensive system health metrics"""
+    """Return CPU, memory, disk, network, load, uptime, and timestamp."""
     try:
         return {
             "cpu_percent": psutil.cpu_percent(interval=1),
@@ -235,9 +235,259 @@ def health_check():
     }
 
 
+# ---------------------------------------------------------------------------
+# Prometheus metrics endpoint
+#
+# Unauthenticated, plain-text exposition format. Same access-control posture
+# as /health: rely on the operator's network-layer policy (UFW +
+# iptables HARDN-LOCKDOWN, scoped via HARDN_API_ALLOWED_CIDRS) rather than
+# adding a bearer-token dance to a metrics scrape. Everything below reads
+# its source file at request time; missing files just produce no rows for
+# that metric family.
+# ---------------------------------------------------------------------------
+from fastapi.responses import PlainTextResponse  # noqa: E402
+
+ALERTS_FILE = os.environ.get("HARDN_ALERTS_FILE", "/var/log/hardn/alerts.jsonl")
+CRON_SUMMARY_FILE = os.environ.get(
+    "HARDN_CRON_SUMMARY_FILE", "/var/lib/hardn/monitor/cron_summary.json"
+)
+SENTRY_BASELINE_FILE = os.environ.get(
+    "HARDN_SENTRY_BASELINE_FILE", "/var/lib/hardn/sentry/baseline.json"
+)
+LEGION_DB_DIR = os.environ.get("HARDN_LEGION_DB_DIR", "/var/lib/hardn/legion")
+
+# Service units we report up/down for. Keep small so the metric stays cheap.
+TRACKED_SERVICES = [
+    "hardn.service",
+    "hardn-api.service",
+    "hardn-monitor.service",
+    "legion-daemon.service",
+]
+
+
+def _prom_escape_label_value(value: str) -> str:
+    """Escape a Prometheus label value per the exposition format spec."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _collect_alert_counts():
+    """Tally alerts.jsonl by severity and by (sentry verb, category).
+
+    Returns (severity_counts, sentry_counts). On read error returns empty
+    dicts so the metric family becomes a no-op rather than 500-ing the
+    scrape.
+    """
+    import json as _json
+
+    severity_counts: Dict[str, int] = {}
+    sentry_counts: Dict[tuple, int] = {}
+    try:
+        with open(ALERTS_FILE, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = _json.loads(line)
+                except Exception:
+                    continue
+                sev = rec.get("severity", "info")
+                severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+                source = rec.get("source", "")
+                if source.startswith("sentry/"):
+                    category = source.split("/", 1)[1]
+                    key_field = rec.get("key", "")
+                    # key shape: sentry:<category>:<verb>:<path>
+                    parts = key_field.split(":", 3)
+                    verb = parts[2] if len(parts) >= 4 else "unknown"
+                    bucket = (verb, category)
+                    sentry_counts[bucket] = sentry_counts.get(bucket, 0) + 1
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        logger.warning("metrics: error reading %s: %s", ALERTS_FILE, e)
+    return severity_counts, sentry_counts
+
+
+def _collect_cron_metrics():
+    """Read /var/lib/hardn/monitor/cron_summary.json and return per-job rows."""
+    import json as _json
+
+    try:
+        with open(CRON_SUMMARY_FILE, "r", encoding="utf-8") as f:
+            doc = _json.load(f)
+    except FileNotFoundError:
+        return []
+    except Exception as e:
+        logger.warning("metrics: error reading %s: %s", CRON_SUMMARY_FILE, e)
+        return []
+
+    jobs = doc.get("jobs", []) if isinstance(doc, dict) else []
+    out = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = job.get("name") or "unknown"
+        last_run = job.get("last_run")
+        last_success = job.get("last_success")
+        last_duration = job.get("last_duration_seconds")
+        last_ts = None
+        if last_run:
+            try:
+                # rfc3339 to unix
+                last_ts = datetime.fromisoformat(
+                    last_run.replace("Z", "+00:00")
+                ).timestamp()
+            except Exception:
+                last_ts = None
+        out.append(
+            {
+                "name": name,
+                "last_run_ts": last_ts,
+                "last_success": last_success,
+                "last_duration_seconds": last_duration,
+            }
+        )
+    return out
+
+
+def _service_up(unit: str) -> int:
+    """Return 1 if systemctl reports the unit active, 0 otherwise."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", unit],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        return 1 if result.stdout.strip() == "active" else 0
+    except Exception:
+        return 0
+
+
+def _baseline_age_seconds(path: str):
+    """Return mtime age in seconds, or None if the file isn't there."""
+    try:
+        st = os.stat(path)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+    return max(0.0, time.time() - st.st_mtime)
+
+
+def _legion_db_present() -> int:
+    try:
+        for entry in os.listdir(LEGION_DB_DIR):
+            if entry.endswith(".db"):
+                return 1
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        return 0
+    return 0
+
+
+@app.get("/metrics", response_class=PlainTextResponse)
+def prometheus_metrics():
+    """Expose HARDN telemetry in Prometheus text exposition format."""
+    lines = []
+    a = lines.append
+
+    # Build info
+    a("# HELP hardn_info HARDN build info, value is always 1.")
+    a("# TYPE hardn_info gauge")
+    a('hardn_info{version="1.0.0-1"} 1')
+
+    # Service up/down
+    a("# HELP hardn_service_up systemctl is-active==1 for a tracked HARDN unit.")
+    a("# TYPE hardn_service_up gauge")
+    for unit in TRACKED_SERVICES:
+        a(
+            'hardn_service_up{{service="{}"}} {}'.format(
+                _prom_escape_label_value(unit), _service_up(unit)
+            )
+        )
+
+    # Alert totals (cumulative within the current alerts.jsonl file)
+    severity_counts, sentry_counts = _collect_alert_counts()
+    a("# HELP hardn_alerts_total Alerts recorded in /var/log/hardn/alerts.jsonl.")
+    a("# TYPE hardn_alerts_total counter")
+    for sev, count in sorted(severity_counts.items()):
+        a(
+            'hardn_alerts_total{{severity="{}"}} {}'.format(
+                _prom_escape_label_value(sev), count
+            )
+        )
+
+    # Sentry drift
+    a("# HELP hardn_sentry_drift_total SENTRY file drift alerts by verb and category.")
+    a("# TYPE hardn_sentry_drift_total counter")
+    for (verb, category), count in sorted(sentry_counts.items()):
+        a(
+            'hardn_sentry_drift_total{{verb="{}",category="{}"}} {}'.format(
+                _prom_escape_label_value(verb),
+                _prom_escape_label_value(category),
+                count,
+            )
+        )
+
+    # Cron job state
+    cron_rows = _collect_cron_metrics()
+    if cron_rows:
+        a("# HELP hardn_cron_last_run_timestamp_seconds Unix ts of last cron run.")
+        a("# TYPE hardn_cron_last_run_timestamp_seconds gauge")
+        for row in cron_rows:
+            if row["last_run_ts"] is None:
+                continue
+            a(
+                'hardn_cron_last_run_timestamp_seconds{{job="{}"}} {}'.format(
+                    _prom_escape_label_value(row["name"]), row["last_run_ts"]
+                )
+            )
+        a("# HELP hardn_cron_last_success 1 if last cron run succeeded.")
+        a("# TYPE hardn_cron_last_success gauge")
+        for row in cron_rows:
+            if row["last_success"] is None:
+                continue
+            a(
+                'hardn_cron_last_success{{job="{}"}} {}'.format(
+                    _prom_escape_label_value(row["name"]),
+                    1 if row["last_success"] else 0,
+                )
+            )
+        a("# HELP hardn_cron_last_duration_seconds Wall-clock seconds of last cron run.")
+        a("# TYPE hardn_cron_last_duration_seconds gauge")
+        for row in cron_rows:
+            if row["last_duration_seconds"] is None:
+                continue
+            a(
+                'hardn_cron_last_duration_seconds{{job="{}"}} {}'.format(
+                    _prom_escape_label_value(row["name"]),
+                    row["last_duration_seconds"],
+                )
+            )
+
+    # SENTRY baseline freshness
+    sentry_age = _baseline_age_seconds(SENTRY_BASELINE_FILE)
+    if sentry_age is not None:
+        a("# HELP hardn_sentry_baseline_age_seconds Seconds since the SENTRY baseline was last written.")
+        a("# TYPE hardn_sentry_baseline_age_seconds gauge")
+        a("hardn_sentry_baseline_age_seconds {:.0f}".format(sentry_age))
+
+    # LEGION baseline present
+    a("# HELP hardn_legion_baseline_present 1 if a LEGION baseline SQLite DB exists.")
+    a("# TYPE hardn_legion_baseline_present gauge")
+    a("hardn_legion_baseline_present {}".format(_legion_db_present()))
+
+    a("")  # exposition format requires a trailing newline
+    return "\n".join(lines)
+
+
 @app.get("/overwatch/system")
 def get_system_overwatch(api_key: str = Depends(verify_ssh_key)):
-    """Get comprehensive system overwatch data"""
+    """Return endpoint identity, system health, and tracked service states."""
     return {
         "endpoint_id": os.uname().nodename,
         "system_health": get_system_health(),
@@ -416,7 +666,7 @@ def get_legion_logs(lines: int = 50, api_key: str = Depends(verify_ssh_key)):
 
 @app.get("/diagnostics/full")
 def get_full_diagnostics(api_key: str = Depends(verify_ssh_key)):
-    """Get comprehensive system diagnostics"""
+    """Return system health, service status, build info, and timestamp."""
     return {
         "endpoint_id": os.uname().nodename,
         "system_info": {
@@ -463,7 +713,7 @@ if __name__ == "__main__":
     print(
         "Remote access: Grafana (port 9002) and HARDN API (port 8000) only. SSH port 22 is closed."
     )
-    print(f"Auth: SSH public key required — add keys to {AUTHORIZED_KEYS_FILE}")
+    print(f"Auth: SSH public key required. Add keys to {AUTHORIZED_KEYS_FILE}")
     print("API endpoints:")
     print("  GET /health - Health check")
     print("  GET /overwatch/system - System overwatch data")

--- a/src/hardn-api.py
+++ b/src/hardn-api.py
@@ -457,7 +457,9 @@ def prometheus_metrics():
                     1 if row["last_success"] else 0,
                 )
             )
-        a("# HELP hardn_cron_last_duration_seconds Wall-clock seconds of last cron run.")
+        a(
+            "# HELP hardn_cron_last_duration_seconds Wall-clock seconds of last cron run."
+        )
         a("# TYPE hardn_cron_last_duration_seconds gauge")
         for row in cron_rows:
             if row["last_duration_seconds"] is None:
@@ -472,7 +474,9 @@ def prometheus_metrics():
     # SENTRY baseline freshness
     sentry_age = _baseline_age_seconds(SENTRY_BASELINE_FILE)
     if sentry_age is not None:
-        a("# HELP hardn_sentry_baseline_age_seconds Seconds since the SENTRY baseline was last written.")
+        a(
+            "# HELP hardn_sentry_baseline_age_seconds Seconds since the SENTRY baseline was last written."
+        )
         a("# TYPE hardn_sentry_baseline_age_seconds gauge")
         a("hardn_sentry_baseline_age_seconds {:.0f}".format(sentry_age))
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1952,12 +1952,7 @@ fn get_tool_categories() -> Vec<ToolCategory> {
         ),
         ToolCategory::new(
             "System Monitoring",
-            vec![
-                "audit",
-                "prometheus_monitoring",
-                "centralized_logging",
-                "auditd",
-            ],
+            vec!["audit", "auditd", "prometheus", "grafana"],
         ),
         ToolCategory::new(
             "System Management",
@@ -3157,7 +3152,7 @@ fn handle_run_tool(tool_dirs: &[PathBuf], tool_name: &str, module_dirs: &[PathBu
 }
 
 /// Run the sentry baseline-diff check. Prints a short report and exits 0
-/// on success — alerts are emitted via the shared alert channel.
+/// on success. Alerts are emitted via the shared alert channel.
 fn run_sentry_check() -> i32 {
     let report = crate::legion::modules::sentry::run_check();
     if report.first_run {

--- a/src/setup/main.rs
+++ b/src/setup/main.rs
@@ -101,7 +101,7 @@ use std::fmt;
 use std::error::Error;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Application version — read from Cargo.toml at compile time so it always
+/// Application version. Read from Cargo.toml at compile time so it always
 /// matches the release tag. To change the displayed version, update `version`
 /// in Cargo.toml only.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -117,7 +117,7 @@ const DEFAULT_LIB_DIR: &str = "/var/lib/hardn";
 const EXIT_SUCCESS: i32 = 0;
 const EXIT_FAILURE: i32 = 1;
 const EXIT_USAGE: i32 = 2;
-/// POSIX "command not found" — returned by run-tool / run-module when the
+/// POSIX "command not found". Returned by run-tool / run-module when the
 /// requested script doesn't exist, so callers can distinguish missing from failed.
 const EXIT_NOT_FOUND: i32 = 127;
 
@@ -893,7 +893,7 @@ fn get_tool_categories() -> Vec<ToolCategory> {
         ),
         ToolCategory::new(
             "System Monitoring",
-            vec!["audit", "prometheus_monitoring", "centralized_logging", "auditd"],
+            vec!["audit", "auditd", "prometheus", "grafana"],
         ),
         ToolCategory::new(
             "System Management",

--- a/usr/share/hardn/tools/grafana.sh
+++ b/usr/share/hardn/tools/grafana.sh
@@ -7,14 +7,19 @@ set -euo pipefail
 # What this does:
 #   - Ensures Grafana APT repo and key exist
 #   - Installs Grafana if missing
-#   - Forces Grafana to listen on port 9002
+#   - Forces Grafana to listen on $HARDN_GRAFANA_PORT (default 3000;
+#     same value used by the UFW + iptables HARDN-LOCKDOWN chain in
+#     modules/hardening.sh, so the firewall and the daemon stay in sync)
+#   - Provisions a default Prometheus data source pointed at the local
+#     Prometheus (http://localhost:9090) so Grafana lights up with data
+#     as soon as tools/prometheus.sh has run
 #   - Enables and starts the service
 #   - Verifies health via curl against loopback
 #
 # Designed to be:
 #   - Idempotent (safe to run multiple times)
 #   - Tolerant of transient repo/network failures
-#   - Non-breaking for “Run ALL tools” workflows
+#   - Non-breaking for "Run ALL tools" workflows
 # ------------------------------------------------------------
 
 source "$(cd "$(dirname "$0")" && pwd)/functions.sh"
@@ -65,12 +70,12 @@ ensure_grafana_repo() {
 
 
 # ------------------------------------------------------------
-# Ensure Grafana listens on port 9002
+# Ensure Grafana listens on the configured port
 # modifies grafana.ini and adds a systemd override
 # ------------------------------------------------------------
 ensure_grafana_port() {
 
-    local desired_port="9002"
+    local desired_port="${HARDN_GRAFANA_PORT:-3000}"
     local ini="/etc/grafana/grafana.ini"
     local override_dir="/etc/systemd/system/grafana-server.service.d"
     local override_file="${override_dir}/override.conf"
@@ -124,7 +129,8 @@ EOF
 # ------------------------------------------------------------
 grafana_health_check() {
 
-    local url="http://127.0.0.1:9002/api/health"
+    local port="${HARDN_GRAFANA_PORT:-3000}"
+    local url="http://127.0.0.1:${port}/api/health"
     local attempts=15
     local delay=2
 
@@ -141,7 +147,7 @@ grafana_health_check() {
         code=$(curl -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null)
 
         if [ "$code" = "200" ]; then
-            HARDN_STATUS "pass" "Grafana is healthy on port 9002"
+            HARDN_STATUS "pass" "Grafana is healthy on port ${port}"
             HARDN_STATUS "info" "Health response: $response"
             return 0
         fi
@@ -149,8 +155,39 @@ grafana_health_check() {
         sleep "$delay"
     done
 
-    HARDN_STATUS "error" "Grafana did not report healthy on port 9002"
+    HARDN_STATUS "error" "Grafana did not report healthy on port ${port}"
     return 1
+}
+
+# ------------------------------------------------------------
+# Drop a default Prometheus data-source provisioning file so
+# Grafana auto-loads it at startup. Idempotent: rewrites the file
+# every run so HARDN_PROMETHEUS_URL changes are picked up.
+# ------------------------------------------------------------
+ensure_prometheus_datasource() {
+    local ds_dir="/etc/grafana/provisioning/datasources"
+    local ds_file="${ds_dir}/hardn-prometheus.yaml"
+    local prom_url="${HARDN_PROMETHEUS_URL:-http://localhost:9090}"
+
+    install -d -m 0755 "$ds_dir" 2>/dev/null || true
+
+    cat > "$ds_file" <<EOF
+# Managed by HARDN tools/grafana.sh. Do not edit by hand.
+apiVersion: 1
+datasources:
+  - name: HARDN Prometheus
+    type: prometheus
+    access: proxy
+    url: ${prom_url}
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: "30s"
+EOF
+    chown root:grafana "$ds_file" 2>/dev/null || true
+    chmod 0640 "$ds_file" 2>/dev/null || true
+
+    HARDN_STATUS "info" "Grafana data source provisioned: ${prom_url}"
 }
 
 HARDN_STATUS "info" "Ensuring Grafana package is installed"
@@ -178,6 +215,8 @@ fi
 # Apply port configuration
 ensure_grafana_port
 
+# Drop Prometheus data source so Grafana boots with data wired in
+ensure_prometheus_datasource
 
 # Enable and start
 HARDN_STATUS "info" "Enabling and starting Grafana service"
@@ -194,16 +233,17 @@ systemctl restart grafana-server 2>/dev/null || true
 grafana_health_check || true
 
 # Open UFW rule for Grafana port if UFW is active
+GRAFANA_PORT="${HARDN_GRAFANA_PORT:-3000}"
 if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "^Status: active"; then
-    if ufw allow in 9002/tcp comment 'Grafana dashboard' 2>/dev/null; then
-        HARDN_STATUS "pass" "UFW rule added: allow inbound port 9002/tcp (Grafana)"
+    if ufw allow in "${GRAFANA_PORT}/tcp" comment 'Grafana dashboard' 2>/dev/null; then
+        HARDN_STATUS "pass" "UFW rule added: allow inbound port ${GRAFANA_PORT}/tcp (Grafana)"
     else
-        HARDN_STATUS "warning" "Failed to add UFW rule for port 9002 — add manually: ufw allow in 9002/tcp"
+        HARDN_STATUS "warning" "Failed to add UFW rule for port ${GRAFANA_PORT}. Add manually: ufw allow in ${GRAFANA_PORT}/tcp"
     fi
 else
-    HARDN_STATUS "info" "UFW not active — if UFW is enabled later, run: ufw allow in 9002/tcp"
+    HARDN_STATUS "info" "UFW not active. If UFW is enabled later, run: ufw allow in ${GRAFANA_PORT}/tcp"
 fi
 
 HARDN_STATUS "info" "Grafana setup complete"
-HARDN_STATUS "info" "Access URL: http://localhost:9002"
+HARDN_STATUS "info" "Access URL: http://localhost:${GRAFANA_PORT}"
 HARDN_STATUS "info" "Default credentials: admin / admin (change immediately)"

--- a/usr/share/hardn/tools/prometheus.sh
+++ b/usr/share/hardn/tools/prometheus.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -euo pipefail
+
+# ------------------------------------------------------------
+# Prometheus installation + scrape-config for HARDN
+# ------------------------------------------------------------
+# What this does:
+#   - Installs prometheus + prometheus-node-exporter from Debian
+#     (Prometheus is in main since Debian 12; no third-party repo needed)
+#   - Writes a HARDN-specific scrape job pointed at the hardn-api
+#     /metrics endpoint on $HARDN_API_PORT (default 8000)
+#   - Opens UFW for $HARDN_PROMETHEUS_PORT (default 9090) when UFW is
+#     active. Same allowlist story as Grafana: scope via
+#     HARDN_PROMETHEUS_ALLOWED_CIDRS or leave open on a localhost-only host.
+#   - Enables + restarts the service and runs a /-/ready probe
+#
+# Sources Prometheus reads off:
+#   localhost:9100  prometheus-node-exporter (host CPU/mem/disk/network)
+#   localhost:9090  prometheus itself (self-monitoring)
+#   localhost:8000  hardn-api /metrics (HARDN service health, alerts,
+#                                       SENTRY drift, cron job state)
+#
+# Designed to be:
+#   - Idempotent (safe to run multiple times)
+#   - Container-aware (skips daemon install in unprivileged containers
+#     where the data dir cannot be persisted)
+# ------------------------------------------------------------
+
+source "$(cd "$(dirname "$0")" && pwd)/functions.sh"
+
+check_root
+log_tool_execution "prometheus.sh"
+
+hardn_detect_env
+
+if hardn_in_container; then
+    HARDN_STATUS "info" "Container detected (${HARDN_ENV_VIRT}); skipping Prometheus install (no persistent data dir)"
+    exit 0
+fi
+
+PROM_PORT="${HARDN_PROMETHEUS_PORT:-9090}"
+API_PORT="${HARDN_API_PORT:-8000}"
+NODE_EXPORTER_PORT="${HARDN_NODE_EXPORTER_PORT:-9100}"
+PROM_DROPIN="/etc/prometheus/prometheus.d/hardn-scrape.yml"
+
+HARDN_STATUS "info" "Installing Prometheus + node exporter"
+if ! install_package prometheus; then
+    HARDN_STATUS "warning" "Prometheus package not available; skipping"
+    exit 0
+fi
+install_package prometheus-node-exporter || \
+    HARDN_STATUS "warning" "prometheus-node-exporter not installed; host metrics unavailable"
+
+# ------------------------------------------------------------
+# HARDN scrape config drop-in
+#
+# Debian's prometheus.deb expects a single /etc/prometheus/prometheus.yml
+# and does NOT load drop-ins by default. We append a `scrape_config_files`
+# directive to the main config that pulls in our drop-in directory, then
+# write the drop-in there. This keeps HARDN edits separate from operator
+# edits to the main file.
+# ------------------------------------------------------------
+PROM_CFG="/etc/prometheus/prometheus.yml"
+if [ -f "$PROM_CFG" ]; then
+    if ! grep -q 'scrape_config_files:' "$PROM_CFG" 2>/dev/null; then
+        # Back up before appending
+        cp "$PROM_CFG" "${PROM_CFG}.bak.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
+        cat >> "$PROM_CFG" <<'EOF'
+
+# HARDN-managed scrape configs (do not edit; see /etc/prometheus/prometheus.d/)
+scrape_config_files:
+  - /etc/prometheus/prometheus.d/*.yml
+EOF
+        HARDN_STATUS "info" "Appended scrape_config_files include to ${PROM_CFG}"
+    fi
+fi
+
+install -d -o root -g root -m 0755 /etc/prometheus/prometheus.d
+
+cat > "$PROM_DROPIN" <<EOF
+# Managed by HARDN tools/prometheus.sh. Do not edit by hand.
+scrape_configs:
+  - job_name: hardn-api
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets: ['localhost:${API_PORT}']
+        labels:
+          source: hardn-api
+
+  - job_name: node
+    static_configs:
+      - targets: ['localhost:${NODE_EXPORTER_PORT}']
+        labels:
+          source: node-exporter
+EOF
+chmod 0644 "$PROM_DROPIN"
+HARDN_STATUS "info" "Wrote scrape config to ${PROM_DROPIN}"
+
+# Reload service
+if enable_service prometheus; then
+    HARDN_STATUS "pass" "prometheus.service enabled"
+fi
+systemctl restart prometheus 2>/dev/null || \
+    HARDN_STATUS "warning" "Could not restart prometheus.service"
+
+# Health probe
+if command -v curl >/dev/null 2>&1; then
+    for i in 1 2 3 4 5; do
+        code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PROM_PORT}/-/ready" 2>/dev/null || true)
+        if [ "$code" = "200" ]; then
+            HARDN_STATUS "pass" "Prometheus is ready on port ${PROM_PORT}"
+            break
+        fi
+        sleep 2
+    done
+fi
+
+# UFW rule
+if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q '^Status: active'; then
+    if [ -n "${HARDN_PROMETHEUS_ALLOWED_CIDRS:-}" ]; then
+        for cidr in ${HARDN_PROMETHEUS_ALLOWED_CIDRS}; do
+            ufw allow proto tcp from "$cidr" to any port "$PROM_PORT" comment 'Prometheus (scoped)' >/dev/null 2>&1 || true
+        done
+        HARDN_STATUS "pass" "UFW rules added for Prometheus, scoped to: ${HARDN_PROMETHEUS_ALLOWED_CIDRS}"
+    else
+        ufw allow in "${PROM_PORT}/tcp" comment 'Prometheus dashboard' >/dev/null 2>&1 || true
+        HARDN_STATUS "info" "UFW rule added: allow inbound port ${PROM_PORT}/tcp (Prometheus)"
+        HARDN_STATUS "info" "Restrict with HARDN_PROMETHEUS_ALLOWED_CIDRS=10.0.0.0/8,..."
+    fi
+fi
+
+HARDN_STATUS "info" "Prometheus setup complete"
+HARDN_STATUS "info" "Access URL: http://localhost:${PROM_PORT}"
+HARDN_STATUS "info" "HARDN metrics endpoint scraped: http://localhost:${API_PORT}/metrics"


### PR DESCRIPTION
## Summary

PR-G plumbs HARDN through Prometheus + Grafana end to end. Closes the gap
from the SSH / Grafana / Prometheus / API status review: HARDN exposes no
metrics, Grafana ships blind, the Rust code listed `prometheus_monitoring`
as a tool that doesn't exist.

### New: `GET /metrics` on `hardn-api`

Prometheus text exposition format, unauthenticated (same access-control
posture as `/health`: rely on the UFW + iptables `HARDN-LOCKDOWN` chain
scoped via `HARDN_API_ALLOWED_CIDRS`, not a bearer dance on a scrape
endpoint).

| Series | Source |
|---|---|
| `hardn_info{version}` | build metadata |
| `hardn_service_up{service}` | `systemctl is-active` for the four HARDN units |
| `hardn_alerts_total{severity}` | `/var/log/hardn/alerts.jsonl` |
| `hardn_sentry_drift_total{verb,category}` | SENTRY-source alerts |
| `hardn_cron_last_{run_timestamp_seconds,success,duration_seconds}{job}` | `/var/lib/hardn/monitor/cron_summary.json` |
| `hardn_sentry_baseline_age_seconds` | mtime of SENTRY baseline.json |
| `hardn_legion_baseline_present` | presence of `/var/lib/hardn/legion/*.db` |

Source paths are overridable via env vars (`HARDN_ALERTS_FILE`,
`HARDN_CRON_SUMMARY_FILE`, `HARDN_SENTRY_BASELINE_FILE`,
`HARDN_LEGION_DB_DIR`) for testing.

### New: `tools/prometheus.sh`

Installs `prometheus` + `prometheus-node-exporter` from Debian main, appends
a `scrape_config_files` include to the shipped `/etc/prometheus/prometheus.yml`,
then writes a HARDN scrape drop-in pointed at `localhost:8000/metrics` plus
the node exporter on `localhost:9100`. Container-aware (skips on unprivileged
containers). Env knobs: `HARDN_PROMETHEUS_PORT` (9090),
`HARDN_NODE_EXPORTER_PORT` (9100), `HARDN_PROMETHEUS_ALLOWED_CIDRS`.

### Fixes in `tools/grafana.sh`

- **Now honours `HARDN_GRAFANA_PORT`** (default 3000) end to end. The
  script previously hard-coded `9002`, which mismatched the UFW rule
  written by `modules/hardening.sh`. The firewall opened 3000, the daemon
  listened on 9002. Now they agree.
- **Provisions a default data source** at
  `/etc/grafana/provisioning/datasources/hardn-prometheus.yaml` pointed at
  `HARDN_PROMETHEUS_URL` (default `http://localhost:9090`). Grafana boots
  with data wired in as soon as `tools/prometheus.sh` has run.

### Misleading placeholder removed

`src/main.rs` and `src/setup/main.rs` listed `prometheus_monitoring` in
the System Monitoring tool category. There was no such tool. Replaced
with `["audit", "auditd", "prometheus", "grafana"]`; every name now maps
to a script under `usr/share/hardn/tools/`.

### Style scrub

Three pre-existing em-dashes in `src/hardn-api.py` and three I introduced
in earlier PRs (`src/main.rs` sentry comment, two `src/setup/main.rs`
comments) removed. Three "comprehensive" docstrings in `hardn-api.py`
rewritten to describe what each function actually returns.

## Test plan

- [x] `cargo test --bin hardn` → 17 passed
- [x] `cargo check --bins` → clean
- [x] `python3 -m py_compile src/hardn-api.py` → OK
- [x] `bash -n` on both shell tools → OK
- [x] `/metrics` smoke test on synthetic `alerts.jsonl` + `cron_summary.json` renders the expected counters and gauges
- [x] No `claude` / `anthropic` / `copilot` / `openai` strings in any modified file
- [x] No em-dashes (`—`) in any modified file
- [ ] CI passes
- [ ] On a real host: `sudo hardn run-tool prometheus && sudo hardn run-tool grafana` produces a Grafana instance on port 3000 with a working Prometheus data source, scraping `hardn-api` `/metrics`
- [ ] Prometheus shows `hardn_sentry_drift_total` increment after running `hardn --sentry-check` against a modified `/etc/cron.d/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_