### PR TITLE
Docs: plug PR-G observability coverage gaps in five remaining docs (PR-H)

### DIFF
--- a/docs/diagram.md
+++ b/docs/diagram.md
@@ -136,7 +136,7 @@ graph TD
 
 ## HARDN Monitor
 - the mermaid architecture of the HARDN Monitor detailing how it gathers data from in-cluster services and supplies read-only outputs to the GUI.
-- HARDN Monitor aggregates operational data from HARDN Service, LEGION, HARDN API, and Grafana, normalizes it into read-only datasets, and exposes those to the GUI without any Prometheus integration.
+- HARDN Monitor aggregates operational data from HARDN Service, LEGION, HARDN API, Prometheus, and Grafana, normalizes it into read-only datasets, and exposes those to the GUI. The HARDN API publishes a `/metrics` endpoint that Prometheus scrapes; Grafana reads Prometheus and renders dashboards.
 
 ```mermaid
 graph TD
@@ -144,7 +144,9 @@ graph TD
         HS[HARDN Service]
         LG[LEGION]
         API[HARDN API]
+        PROM[Prometheus]
         GF[Grafana]
+        NE[node-exporter]
     end
 
     subgraph HARDN Monitor
@@ -159,7 +161,10 @@ graph TD
 
     HS --> COL
     LG --> COL
-    API --> COL
+    API -->|/metrics| PROM
+    NE --> PROM
+    PROM --> GF
+    PROM --> COL
     GF --> COL
 
     COL --> NORM
@@ -189,7 +194,7 @@ graph TD
     UI --> DASH
 
     subgraph Data Sources
-        TS[(Time-Series Database)]
+        TS[(Prometheus<br/>provisioned by HARDN<br/>tools/grafana.sh)]
         LOG[(Log Store)]
         RO[(HARDN Monitor Read-Only Data)]
     end

--- a/docs/hardn-monitor.md
+++ b/docs/hardn-monitor.md
@@ -83,6 +83,33 @@ overridden with `HARDN_ALERT_JOURNALD_TAG` and `HARDN_ALERT_DEDUPE_PATH`.
 The GUI tails `alerts.jsonl` and collapses repeats of the same `key` into
 a single updating row.
 
+## Prometheus Metrics Endpoint
+
+`hardn-api` publishes a `GET /metrics` endpoint in Prometheus text
+exposition format. Unauthenticated; rely on the network-layer policy
+already enforced by UFW and the iptables `HARDN-LOCKDOWN` chain
+(scoped via `HARDN_API_ALLOWED_CIDRS`).
+
+Series exposed:
+
+| Series | Source |
+|---|---|
+| `hardn_info{version}` | build metadata |
+| `hardn_service_up{service}` | `systemctl is-active` for the four HARDN units |
+| `hardn_alerts_total{severity}` | `/var/log/hardn/alerts.jsonl` |
+| `hardn_sentry_drift_total{verb,category}` | SENTRY-source alerts |
+| `hardn_cron_last_run_timestamp_seconds{job}` | `/var/lib/hardn/monitor/cron_summary.json` |
+| `hardn_cron_last_success{job}` | as above |
+| `hardn_cron_last_duration_seconds{job}` | as above |
+| `hardn_sentry_baseline_age_seconds` | mtime of the SENTRY baseline file |
+| `hardn_legion_baseline_present` | 1 if a LEGION baseline SQLite DB exists |
+
+`tools/prometheus.sh` installs Prometheus + node-exporter and writes
+`/etc/prometheus/prometheus.d/hardn-scrape.yml` pointing at
+`localhost:8000/metrics` and `localhost:9100`. `tools/grafana.sh`
+provisions Grafana with the matching Prometheus data source, so the
+stack runs out of the box on a fresh install.
+
 ## Usage
 
 ### Launching the Monitoring Interface

--- a/docs/hardn-service.md
+++ b/docs/hardn-service.md
@@ -9,7 +9,9 @@ U["User / Admin (Remote)"] -->|"HARDN API: port 8000, SSH key auth"| API[HARDN A
 U -->|"Grafana Dashboard: port 3000"| GRF[Grafana]
 CLI[hardn CLI] -->|manual execution| CORE[HARDN Core Service]
 API -->|remote trigger| CORE
-GRF -->|datasource queries| API
+PROM[Prometheus<br/>port 9090] -->|scrapes /metrics| API
+NEXP[node-exporter<br/>port 9100] --> PROM
+GRF -->|queries| PROM
 
 %% ===================== SERVICE COMPONENTS =====================
 subgraph HARDN Core Framework
@@ -94,6 +96,7 @@ class CORE,SRV daemon
 class MOD,TOOLS,CFG,AUD,LOG,RPT,MON,AUTH,DATA layer
 class APP,F2B,UFW,AUDD,CLAM,RKH,LYN,AIDE tools
 class SYSMD,JRN,CRN,NETM os
+class PROM,NEXP,GRF daemon
 ```
 
 ---
@@ -111,5 +114,7 @@ class SYSMD,JRN,CRN,NETM os
 | **System Logger** | Centralized structured journaling for all modules and API events. |
 | **Security Report Generator** | Produces human-readable and machine-readable summaries for audits. |
 | **Linux Services Integration** | Uses systemd for orchestration, journald for logging, cron for scheduling, and NetworkManager for connectivity. |
+| **Prometheus** | Scrapes `hardn-api` `/metrics` (port 8000) and `prometheus-node-exporter` (port 9100). Installed by `tools/prometheus.sh`. Default port 9090, override with `HARDN_PROMETHEUS_PORT`. |
+| **Grafana** | Dashboard on `HARDN_GRAFANA_PORT` (default 3000). `tools/grafana.sh` provisions the HARDN Prometheus data source so it boots wired in. |
 
 ---

--- a/docs/hardn.md
+++ b/docs/hardn.md
@@ -168,6 +168,31 @@ REST API for remote management and monitoring:
 - Service status
 - Remote command execution (limited command set)
 - Integration with external tools
+- `GET /metrics` exposes HARDN telemetry in Prometheus text format
+  (service up/down, alert counts, SENTRY drift, cron job state,
+  baseline age). Unauthenticated; scoped by the UFW + iptables
+  `HARDN-LOCKDOWN` chain via `HARDN_API_ALLOWED_CIDRS`.
+
+### Observability stack
+
+`tools/prometheus.sh` installs Prometheus and `prometheus-node-exporter`
+from Debian main, then drops a HARDN scrape config at
+`/etc/prometheus/prometheus.d/hardn-scrape.yml` pointed at
+`localhost:8000/metrics` and the node exporter on `localhost:9100`.
+
+`tools/grafana.sh` installs Grafana on `HARDN_GRAFANA_PORT` (default 3000)
+and provisions a default Prometheus data source at
+`/etc/grafana/provisioning/datasources/hardn-prometheus.yaml`. Grafana
+boots with HARDN telemetry already wired in.
+
+Bring the stack up on a fresh host:
+
+```bash
+sudo hardn run-tool prometheus && sudo hardn run-tool grafana
+```
+
+Then browse to `http://<host>:3000` (admin / admin, change immediately).
+The HARDN Prometheus data source is pre-configured.
 
 ### Hardening modules
 

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -100,6 +100,22 @@ This document provides a consolidated view of the security controls implemented 
   (default 6 h, override `HARDN_ALERT_DEDUPE_TTL_SEC`) prevents
   pager-spam.
 
+### Observability Stack
+
+- `hardn-api` exposes `GET /metrics` in Prometheus text format. Series
+  cover service up/down, alert counts by severity, SENTRY drift by verb
+  and category, cron last-run timestamps and success flags, SENTRY
+  baseline age, and LEGION baseline presence. Unauthenticated; relies on
+  the UFW + iptables `HARDN-LOCKDOWN` chain scoped via
+  `HARDN_API_ALLOWED_CIDRS` for access control.
+- `tools/prometheus.sh` installs Prometheus + `prometheus-node-exporter`
+  from Debian main and writes a HARDN scrape drop-in pointed at the
+  `/metrics` endpoint plus the node exporter. Skipped in unprivileged
+  containers.
+- `tools/grafana.sh` installs Grafana on `HARDN_GRAFANA_PORT` (default
+  3000) and provisions a default Prometheus data source so the dashboard
+  boots wired in. UFW rule is added when UFW is active.
+
 ## Operational Considerations
 
 - **Policy Files**: `/etc/hardn/compiler-policy.conf` controls compiler stance; ensure infrastructure-as-code or configuration management sets it explicitly.


### PR DESCRIPTION
## Summary

Patches the five docs that PR-G touched the code in but didn't update the prose for. Most importantly, drops the "without any Prometheus integration" line in `docs/diagram.md:139` which became factually wrong the moment PR-G merged.

### Changes

| File | What |
|---|---|
| `docs/diagram.md` | Removes the "without any Prometheus integration" claim. Adds Prometheus + node-exporter nodes to the HARDN Monitor mermaid. Grafana data-source node now labelled correctly as Prometheus-provisioned-by-HARDN. |
| `docs/hardn.md` | API service bullets list `/metrics`. New **Observability stack** subsection covers `tools/prometheus.sh` + `tools/grafana.sh` and the one-line bring-up command. |
| `docs/hardn-monitor.md` | New **Prometheus Metrics Endpoint** section with a table of every exposed series. |
| `docs/security-posture.md` | New **Observability Stack** subsection under Reporting & Response. |
| `docs/hardn-service.md` | Mermaid gains Prometheus (9090) and node-exporter (9100); Grafana now arrows into Prometheus. Architecture Summary table gains Prometheus + Grafana rows. |

### Test plan

- [x] 0 em-dashes (`—`) in any touched file
- [x] 0 AI-tells (`comprehensive`, `seamless`, `robust`, `delve`, `leverage`, etc.) introduced
- [x] 0 `claude` / `anthropic` / `copilot` / `openai` strings
- [ ] CI passes (docs-only, no code touched)
- [ ] Mermaid renders cleanly on github.com for `docs/diagram.md` and `docs/hardn-service.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xbeiPGrxS2HvTr8pA9c8)_