### PR TITLE
PR-E: subsystem CODEOWNERS, PR template, SPDX headers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,58 @@
 # HARDN code owners.
 #
-# Lines later in this file take precedence over earlier ones. The default
-# pattern below means @OpenSource-For-Freedom is requested as a reviewer
-# for any change that doesn't match a more specific pattern below.
+# Lines later in this file take precedence over earlier ones, so the
+# catch-all default sits first and the specific subsystem rules below
+# override it. Each entry requests the listed owner(s) as reviewers on a
+# change that touches that path. Ownership is by subsystem so there is a
+# named reviewer trail for each area, not a single blanket owner.
 #
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
 
-*       @OpenSource-For-Freedom
+# Catch-all default: anything not matched by a rule below.
+*                               @OpenSource-For-Freedom
+
+# LEGION engine and its modules (sentry drift, risk scoring, threat
+# intel, behavioral, correlation, heuristics).
+src/legion/                     @OpenSource-For-Freedom
+
+# CLI, setup, execution, and display layers of the hardn binary.
+src/cli/                        @OpenSource-For-Freedom
+src/core/                       @OpenSource-For-Freedom
+src/execution/                  @OpenSource-For-Freedom
+src/setup/                      @OpenSource-For-Freedom
+src/services/                   @OpenSource-For-Freedom
+src/display/                    @OpenSource-For-Freedom
+src/utils/                      @OpenSource-For-Freedom
+
+# The compliance auditor (C).
+src/audit/                      @OpenSource-For-Freedom
+
+# GTK4 desktop viewer and the service monitor.
+src/hardn-gui.rs                @OpenSource-For-Freedom
+src/hardn-monitor.rs            @OpenSource-For-Freedom
+
+# Python REST API. Slated for replacement by a Rust axum service; until
+# then changes here need review because it is the one non-Rust runtime.
+src/hardn-api.py                @OpenSource-For-Freedom
+
+# Shell tool integrations run as root during hardening.
+usr/share/hardn/tools/          @OpenSource-For-Freedom
+usr/share/hardn/modules/        @OpenSource-For-Freedom
+usr/share/hardn/scripts/        @OpenSource-For-Freedom
+
+# systemd units.
+systemd/                        @OpenSource-For-Freedom
+
+# Debian packaging.
+debian/                         @OpenSource-For-Freedom
+
+# CI, security policy, and repo automation.
+.github/                        @OpenSource-For-Freedom
+
+# Supply-chain and toolchain pins.
+deny.toml                       @OpenSource-For-Freedom
+rust-toolchain.toml             @OpenSource-For-Freedom
+Cargo.toml                      @OpenSource-For-Freedom
+
+# Test harness.
+tests/                          @OpenSource-For-Freedom

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What does this PR change, and why? One or two sentences. -->
+
+## Changes
+
+<!-- Bullet the concrete changes. Reference files or subsystems. -->
+
+-
+
+## Testing
+
+<!-- How was this verified? The project runs a TAP harness; paste the
+     relevant result and any manual steps. -->
+
+- [ ] `bash tests/run-all.sh` passes (note pass/fail/skip counts)
+- [ ] `cargo fmt --all -- --check` clean (Rust changes)
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean (Rust changes)
+- [ ] New behavior has a test that fails without the change
+
+## Risk and rollout
+
+<!-- Migration notes, config or env changes operators must make,
+     backward-compatibility concerns, or "none". -->
+
+## Related
+
+<!-- Issue numbers, prior PRs, or audit items this addresses. -->

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /*use clap::{App, Arg};
 
 // mod.rs - CLI module

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /// Application version — read from Cargo.toml at compile time so it always
 /// matches the release tag. To change the displayed version, update `version`
 /// in Cargo.toml only.

--- a/src/core/cron.rs
+++ b/src/core/cron.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Cron job orchestrator for HARDN
 //!
 //! Coordinates recurring maintenance jobs that keep Legion telemetry, HARDN service

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::error::Error;
 use std::fmt;
 use std::io;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod config;
 pub mod cron;
 pub mod error;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /// Service status information
 #[derive(Debug)]
 pub struct ServiceStatus {

--- a/src/display/banner.rs
+++ b/src/display/banner.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /// Prints the HARDN ASCII art banner
 /// Displayed at the start of every program execution
 pub fn print_banner() {

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod banner;
 
 // For now, we'll keep other display functions in the main file

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod runner;
 
 // Re-export commonly used items

--- a/src/execution/runner.rs
+++ b/src/execution/runner.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 

--- a/src/hardn-gui.rs
+++ b/src/hardn-gui.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 

--- a/src/hardn-monitor.rs
+++ b/src/hardn-monitor.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::Utc;
 use serde_json::Value;
 use std::collections::HashMap;

--- a/src/legion/banner.rs
+++ b/src/legion/banner.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // banner display function
 pub fn display_banner() {
     let banner = r#"

--- a/src/legion/core/baseline/mod.rs
+++ b/src/legion/core/baseline/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use rusqlite::{Connection, Result, params};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/legion/core/collectors/cpu.rs
+++ b/src/legion/core/collectors/cpu.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fs;
 use std::thread;
 use std::time::Duration;

--- a/src/legion/core/collectors/database.rs
+++ b/src/legion/core/collectors/database.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use crate::legion::core::baseline::BaselineManager;
 use crate::legion::core::framework::{
     CollectionContext, FrameworkError, TelemetryCategory, TelemetryPayload, TelemetryRecord,

--- a/src/legion/core/collectors/memory.rs
+++ b/src/legion/core/collectors/memory.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fs;
 
 use crate::legion::core::framework::{

--- a/src/legion/core/collectors/mod.rs
+++ b/src/legion/core/collectors/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod cpu;
 pub mod database;
 pub mod memory;

--- a/src/legion/core/config/mod.rs
+++ b/src/legion/core/config/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::env;
 use std::fs;
 use std::path::Path;

--- a/src/legion/core/framework.rs
+++ b/src/legion/core/framework.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 #![allow(dead_code)]
 
 use std::collections::HashMap;

--- a/src/legion/core/framework_pipeline.rs
+++ b/src/legion/core/framework_pipeline.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use crate::legion::core::collectors::{
     CpuTelemetrySource, DatabaseTelemetrySource, MemoryTelemetrySource,
 };

--- a/src/legion/core/heuristics/database.rs
+++ b/src/legion/core/heuristics/database.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use crate::legion::core::framework::{
     AnalysisContext, FindingSeverity, FrameworkError, HeuristicFinding, HeuristicModule,
     TelemetryPayload,

--- a/src/legion/core/heuristics/mod.rs
+++ b/src/legion/core/heuristics/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod database;
 pub mod resource;
 

--- a/src/legion/core/heuristics/resource.rs
+++ b/src/legion/core/heuristics/resource.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use crate::legion::core::framework::{
     AnalysisContext, FindingSeverity, FrameworkError, HeuristicFinding, HeuristicModule,
     TelemetryPayload,

--- a/src/legion/core/legion.rs
+++ b/src/legion/core/legion.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fmt;
 use std::io::{self, Write};
 use std::process::{self, Command};

--- a/src/legion/core/mod.rs
+++ b/src/legion/core/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod baseline;
 pub mod collectors;
 pub mod config;

--- a/src/legion/core/responders/mod.rs
+++ b/src/legion/core/responders/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod noop;
 
 pub use noop::NoopResponder;

--- a/src/legion/core/responders/noop.rs
+++ b/src/legion/core/responders/noop.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use crate::legion::core::framework::{
     Finding, FindingSeverity, FrameworkError, ResponseAction, ResponseContext, ResponseModule,
     ResponseOutcome, ResponseStatus,

--- a/src/legion/functions.rs
+++ b/src/legion/functions.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use once_cell::sync::Lazy;
 use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/legion/mod.rs
+++ b/src/legion/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Legion security HEURISTICS engine module DEMO
 //! This crate exposes two primary groups of functionality:
 //! - `core`: foundational orchestration, configuration, and baseline collectors

--- a/src/legion/modules/auth/mod.rs
+++ b/src/legion/modules/auth/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fs;
 use std::process::Command;
 

--- a/src/legion/modules/behavioral/mod.rs
+++ b/src/legion/modules/behavioral/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/src/legion/modules/containers/mod.rs
+++ b/src/legion/modules/containers/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Containers and build tooling monitoring

--- a/src/legion/modules/correlation/mod.rs
+++ b/src/legion/modules/correlation/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/src/legion/modules/crypto.rs
+++ b/src/legion/modules/crypto.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::path::Path;
 use std::process::Command;
 

--- a/src/legion/modules/filesystem.rs
+++ b/src/legion/modules/filesystem.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::path::Path;
 use std::process::Command;
 

--- a/src/legion/modules/inventory.rs
+++ b/src/legion/modules/inventory.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fs;
 use std::process::Command;
 

--- a/src/legion/modules/kernel.rs
+++ b/src/legion/modules/kernel.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Kernel and low-level monitoring

--- a/src/legion/modules/logs.rs
+++ b/src/legion/modules/logs.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Log analysis and monitoring

--- a/src/legion/modules/memory.rs
+++ b/src/legion/modules/memory.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Memory and resource monitoring

--- a/src/legion/modules/mod.rs
+++ b/src/legion/modules/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod auth;
 pub mod behavioral;
 pub mod containers;

--- a/src/legion/modules/network.rs
+++ b/src/legion/modules/network.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Network and communications monitoring

--- a/src/legion/modules/packages.rs
+++ b/src/legion/modules/packages.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Package and binary integrity checks

--- a/src/legion/modules/permissions.rs
+++ b/src/legion/modules/permissions.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 

--- a/src/legion/modules/processes.rs
+++ b/src/legion/modules/processes.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::process::Command;
 
 /// Process and behavior monitoring

--- a/src/legion/modules/response.rs
+++ b/src/legion/modules/response.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/legion/modules/risk_scoring.rs
+++ b/src/legion/modules/risk_scoring.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/legion/modules/sentry/mod.rs
+++ b/src/legion/modules/sentry/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Sentry: high-value file drift detector ("tattletale phase 1").
 //!
 //! Watches a small, hand-picked list of files that an attacker would have to

--- a/src/legion/modules/services.rs
+++ b/src/legion/modules/services.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // use crate::legion::safe_println;
 use std::process::Command;
 

--- a/src/legion/modules/threat_intel.rs
+++ b/src/legion/modules/threat_intel.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/legion/modules/usb.rs
+++ b/src/legion/modules/usb.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // use crate::legion::safe_println;
 use std::process::Command;
 

--- a/src/legion/modules/vulnerabilities.rs
+++ b/src/legion/modules/vulnerabilities.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // use crate::legion::safe_println;
 use std::process::Command;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // Refactored main.rs - now using modular architecture
 
 mod cli;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // Declare submodules
 
 // Future modules - commented out until implemented

--- a/src/setup/main.rs
+++ b/src/setup/main.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! # HARDN Main Entry Point
 //!
 //! ## Overview

--- a/src/utils/alerts.rs
+++ b/src/utils/alerts.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 //! Shared alert emission for the HARDN alert channel.
 //!
 //! Alerts are appended as JSON lines to `/var/log/hardn/alerts.jsonl`.

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fmt;
 
 /// Log levels for colored console output

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pub mod alerts;
 pub mod logging;
 pub mod paths;

--- a/src/utils/path_security.rs
+++ b/src/utils/path_security.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::path::{Path, PathBuf, Component};
 
 /// Validates and sanitizes a path to prevent path traversal attacks

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::collections::HashSet;
 use std::env;
 use std::fs;

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 use std::fs;
 
 /// Detect the Debian version and codename from /etc/os-release

--- a/tests/static/governance-files.t.sh
+++ b/tests/static/governance-files.t.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Pre-push regression guards for repository governance files.
+#
+# The audit flagged a one-line CODEOWNERS (single owner for the whole
+# tree, no subsystem accountability) and no PR template. This suite
+# locks in subsystem-level ownership and the template so a reviewer
+# trail exists for each area of the codebase.
+#
+# Invariants:
+#
+#   G1  .github/CODEOWNERS assigns an owner to each first-party
+#       subsystem: src/legion, the Python API, the tool scripts,
+#       debian packaging, and the CI workflows. A single catch-all
+#       line is not enough.
+#
+#   G2  A PR template exists at one of the standard locations and
+#       carries the sections a reviewer needs (Summary, testing).
+
+set -u
+
+HARDN_TEST_NAME="static/governance-files"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+CODEOWNERS="$REPO_ROOT/.github/CODEOWNERS"
+
+assert_file_exists "$CODEOWNERS" ".github/CODEOWNERS ships"
+
+tap_plan 8
+
+# G1: each subsystem path must appear as a CODEOWNERS pattern with an
+# @owner on the same line. We match the leading path token, then require
+# an @ later on the line.
+owner_for() {
+    local pat="$1"
+    grep -E "^[[:space:]]*${pat}[[:space:]].*@" "$CODEOWNERS" >/dev/null 2>&1
+}
+
+for entry in \
+    "src/legion/:src/legion subsystem" \
+    "src/hardn-api.py:Python API" \
+    "usr/share/hardn/tools/:tool scripts" \
+    "debian/:packaging" \
+    ".github/:CI workflows" \
+; do
+    pat="${entry%%:*}"
+    label="${entry##*:}"
+    # Escape regex metacharacters in the path for grep -E.
+    esc=$(printf '%s' "$pat" | sed -E 's/[.[\*^$()+?{}|]/\\&/g')
+    if owner_for "$esc"; then
+        tap_ok "CODEOWNERS assigns an owner to $label ($pat)"
+    else
+        tap_not_ok "CODEOWNERS must assign an owner to $label ($pat)"
+    fi
+done
+
+# G1b: a catch-all default line must still exist as a backstop.
+if grep -E '^\*[[:space:]].*@' "$CODEOWNERS" >/dev/null 2>&1; then
+    tap_ok "CODEOWNERS keeps a catch-all default owner line"
+else
+    tap_not_ok "CODEOWNERS must keep a catch-all '*' default owner line"
+fi
+
+# G2: PR template exists at a standard location.
+pr_template=""
+for cand in \
+    "$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md" \
+    "$REPO_ROOT/.github/pull_request_template.md" \
+    "$REPO_ROOT/PULL_REQUEST_TEMPLATE.md" \
+    "$REPO_ROOT/docs/PULL_REQUEST_TEMPLATE.md" \
+; do
+    if [ -f "$cand" ]; then
+        pr_template="$cand"
+        break
+    fi
+done
+
+if [ -n "$pr_template" ]; then
+    tap_ok "a PR template exists (${pr_template#"$REPO_ROOT"/})"
+else
+    tap_not_ok "a PR template must exist at .github/PULL_REQUEST_TEMPLATE.md"
+fi
+
+# G2b: template carries a Summary and a testing section.
+if [ -n "$pr_template" ] \
+   && grep -qiE '## +summary' "$pr_template" \
+   && grep -qiE 'test' "$pr_template"; then
+    tap_ok "PR template has a Summary section and asks about testing"
+else
+    tap_not_ok "PR template must include a Summary section and a testing prompt"
+fi
+
+tap_summary

--- a/tests/static/spdx-headers.t.sh
+++ b/tests/static/spdx-headers.t.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Pre-push regression guard: every Rust source file carries an SPDX
+# license identifier.
+#
+# The audit noted zero SPDX headers across the Rust tree, which makes
+# per-file license provenance hard to track in forks and downstream
+# redistribution. This guard requires each src/**/*.rs to declare its
+# license on the first line so a new file without the header trips CI.
+#
+# Invariant:
+#
+#   X1  Every tracked src/**/*.rs file has
+#       '// SPDX-License-Identifier: MIT' as its first line.
+
+set -u
+
+HARDN_TEST_NAME="static/spdx-headers"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+SPDX_LINE='// SPDX-License-Identifier: MIT'
+
+mapfile -t rs_files < <(find "$REPO_ROOT/src" -type f -name '*.rs' | sort)
+
+# One assertion for the aggregate result keeps the plan stable as files
+# are added; individual offenders are listed as diagnostics.
+tap_plan 1
+
+missing=()
+for f in "${rs_files[@]}"; do
+    first=$(head -n1 "$f")
+    if [ "$first" != "$SPDX_LINE" ]; then
+        missing+=("${f#"$REPO_ROOT"/}")
+    fi
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+    tap_ok "all ${#rs_files[@]} src/**/*.rs files start with '$SPDX_LINE'"
+else
+    tap_not_ok "${#missing[@]} of ${#rs_files[@]} src/**/*.rs files lack the SPDX header on line 1"
+    for m in "${missing[@]}"; do
+        tap_diag "$m"
+    done
+fi
+
+tap_summary


### PR DESCRIPTION
## Summary

Closes the governance gaps from the audit: a one-line CODEOWNERS, no PR template, and zero SPDX headers.

## Changes

- **CODEOWNERS** — replaced the single catch-all with per-subsystem ownership (LEGION, CLI/setup/execution/display, C auditor, GUI + monitor, Python API, shell tools, systemd units, debian packaging, CI workflows, supply-chain/toolchain pins). Catch-all default kept as a backstop. Same owner account for now, but the structure gives a per-area reviewer trail so a second maintainer can take a subsystem by changing one line.
- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — Summary, Changes, Testing, Risk and rollout, Related.
- **SPDX headers** — `// SPDX-License-Identifier: MIT` prepended to all 61 `src/**/*.rs` files. Incidentally normalized `src/main.rs` / `src/setup/main.rs` from mode 755 to 644 (source shouldn't be executable).

## Testing

- `bash tests/run-all.sh`: 30 suites, 229 pass, 0 fail, 1 skip
- fmt / clippy clean
- Guards `governance-files.t.sh` 9/9, `spdx-headers.t.sh` 1/1

No code behavior change; governance/metadata only.