### PR TITLE
PR-D: sign release .deb with cosign keyless + publish SHA256SUMS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      # Required for sigstore cosign keyless signing: the job mints a
+      # short-lived OIDC token that cosign exchanges with Fulcio for a
+      # signing certificate. No long-lived key is stored anywhere.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -308,6 +312,15 @@ jobs:
         with:
           name: hardn-deb-package
           path: release_assets
+
+      - name: Install cosign
+        # NOTE: pinned to the major version tag, not a commit SHA, unlike
+        # the other actions in this repo. The build environment that
+        # authored this change cannot reach the sigstore/cosign-installer
+        # repository to resolve a SHA. Before relying on this in a release,
+        # replace @v3 with the exact '<sha> # v3.x.y' pin to match the
+        # repo's supply-chain convention.
+        uses: sigstore/cosign-installer@v3
 
       - name: Ensure tags are present
         run: |
@@ -417,6 +430,63 @@ jobs:
           } > RELEASE_NOTES.md
         shell: bash
 
+      - name: Sign package and generate checksums (cosign keyless)
+        id: sign
+        working-directory: release_assets
+        env:
+          # Keyless signing: cosign uses the workflow's OIDC identity via
+          # Fulcio + Rekor. No key material is read or written.
+          COSIGN_YES: "true"
+        run: |
+          DEB_NAME="${{ steps.version.outputs.deb_name }}"
+
+          # SHA256SUMS over everything we publish (the .deb and the logo),
+          # so a consumer can verify integrity without cosign too.
+          sha256sum -- *.deb IMG_1233.jpeg > SHA256SUMS
+          cat SHA256SUMS
+
+          # Detached signature + certificate for the .deb. cosign writes
+          # the Rekor transparency-log entry as part of sign-blob.
+          cosign sign-blob \
+            --output-signature "${DEB_NAME}.sig" \
+            --output-certificate "${DEB_NAME}.pem" \
+            "${DEB_NAME}"
+
+          # Sign the checksum manifest too, so the whole asset set is
+          # covered by one verifiable anchor.
+          cosign sign-blob \
+            --output-signature "SHA256SUMS.sig" \
+            --output-certificate "SHA256SUMS.pem" \
+            "SHA256SUMS"
+
+          echo "Signed ${DEB_NAME} and SHA256SUMS with cosign (keyless)."
+
+      - name: Append verification instructions to release notes
+        run: |
+          DEB_NAME="${{ steps.version.outputs.deb_name }}"
+          IDENTITY="https://github.com/${{ github.repository }}/.github/workflows/ci.yml@refs/heads/main"
+          {
+            echo
+            echo "## Verifying this release"
+            echo
+            echo "Every asset is signed with [sigstore cosign](https://docs.sigstore.dev/) keyless signing (no long-lived key). Verify the package:"
+            echo
+            echo '```bash'
+            echo "cosign verify-blob \\"
+            echo "  --certificate ${DEB_NAME}.pem \\"
+            echo "  --signature ${DEB_NAME}.sig \\"
+            echo "  --certificate-identity '${IDENTITY}' \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\"
+            echo "  ${DEB_NAME}"
+            echo '```'
+            echo
+            echo "Or check integrity only:"
+            echo
+            echo '```bash'
+            echo "sha256sum -c SHA256SUMS"
+            echo '```'
+          } >> RELEASE_NOTES.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
         with:
@@ -427,6 +497,11 @@ jobs:
           files: |
             release_assets/*.deb
             release_assets/IMG_1233.jpeg
+            release_assets/SHA256SUMS
+            release_assets/SHA256SUMS.sig
+            release_assets/SHA256SUMS.pem
+            release_assets/*.deb.sig
+            release_assets/*.deb.pem
           draft: false
           prerelease: false
         env:

--- a/tests/static/release-signing.t.sh
+++ b/tests/static/release-signing.t.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Pre-push regression guard: releases are signed and checksummed.
+#
+# The audit flagged that releases shipped an unsigned .deb (softprops
+# upload, no signature, no cosign, no GPG). Anyone who obtains write
+# access to the release, or MITMs the download, can swap the package.
+# PR-D adds sigstore cosign keyless signing (GitHub OIDC, no long-lived
+# key) plus a SHA256SUMS file, and publishes both as release assets.
+#
+# Invariants (all in the ci.yml release job):
+#
+#   S1  cosign is installed via sigstore/cosign-installer.
+#
+#   S2  A SHA256SUMS file is generated over the release artifact(s).
+#
+#   S3  cosign sign-blob runs against the .deb and emits a detached
+#       signature and certificate.
+#
+#   S4  The release job grants 'id-token: write' (required for keyless
+#       OIDC signing) alongside the existing 'contents: write'.
+#
+#   S5  The signature, certificate, and SHA256SUMS are added to the
+#       release upload file list.
+#
+#   S6  The signing step is not silenced with '|| true'.
+
+set -u
+
+HARDN_TEST_NAME="static/release-signing"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+CI="$REPO_ROOT/.github/workflows/ci.yml"
+
+assert_file_exists "$CI" ".github/workflows/ci.yml ships"
+
+tap_plan 6
+
+# S1: cosign installer present.
+if grep -qE 'sigstore/cosign-installer' "$CI"; then
+    tap_ok "ci.yml installs cosign via sigstore/cosign-installer"
+else
+    tap_not_ok "ci.yml must install cosign (sigstore/cosign-installer)"
+fi
+
+# S2: SHA256SUMS generation.
+if grep -qE 'sha256sum.*(SHA256SUMS|> *SHA256SUMS)' "$CI" || grep -qE 'SHA256SUMS' "$CI"; then
+    tap_ok "ci.yml generates a SHA256SUMS file"
+else
+    tap_not_ok "ci.yml must generate a SHA256SUMS file over the release artifacts"
+fi
+
+# S3: cosign sign-blob invocation.
+if grep -qE 'cosign[[:space:]]+sign-blob' "$CI"; then
+    tap_ok "ci.yml runs 'cosign sign-blob' on the release artifact"
+else
+    tap_not_ok "ci.yml must run 'cosign sign-blob' to sign the .deb"
+fi
+
+# S4: id-token: write permission on the release job. We check the file
+# contains the permission; the workflow only needs it in the release
+# job, which is the sole OIDC consumer.
+if grep -qE 'id-token:[[:space:]]*write' "$CI"; then
+    tap_ok "ci.yml grants 'id-token: write' for keyless OIDC signing"
+else
+    tap_not_ok "the release job must grant 'id-token: write'"
+fi
+
+# S5: signature/cert/checksums added to the release upload list.
+# cosign emits <name>.sig and <name>.pem (or .crt); require the release
+# 'files:' block to reference .sig and SHA256SUMS.
+if grep -qE '\.sig' "$CI" && grep -qE 'SHA256SUMS' "$CI"; then
+    tap_ok "release uploads the signature and SHA256SUMS"
+else
+    tap_not_ok "release 'files:' must include the .sig signature and SHA256SUMS"
+fi
+
+# S6: signing not silenced.
+if grep -qE 'cosign[[:space:]]+sign-blob[^#]*\|\|[[:space:]]+true' "$CI"; then
+    tap_not_ok "cosign sign-blob must not be silenced with '|| true'"
+    grep -nE 'cosign[[:space:]]+sign-blob[^#]*\|\|[[:space:]]+true' "$CI" | sed 's/^/# /'
+else
+    tap_ok "cosign sign-blob is not silenced with '|| true'"
+fi
+
+tap_summary


### PR DESCRIPTION
## Summary

Releases shipped an unsigned `.deb` with no checksum manifest. This adds sigstore **cosign keyless** signing (GitHub OIDC via Fulcio + Rekor — no long-lived key to store or rotate) plus a `SHA256SUMS` file, both published as release assets.

## Changes

In the `release` job of `.github/workflows/ci.yml`:
- Added `id-token: write` permission (required for keyless OIDC).
- Install cosign via `sigstore/cosign-installer`.
- Generate `SHA256SUMS` over the published assets, then `cosign sign-blob` the `.deb` and the manifest into detached `.sig` + `.pem` for each, with a Rekor transparency-log entry.
- Append copy-paste `cosign verify-blob` and `sha256sum -c` instructions to the release notes.
- Upload `*.deb.sig`, `*.deb.pem`, `SHA256SUMS`, `SHA256SUMS.sig`, `SHA256SUMS.pem` alongside the package.

## Note

The `cosign-installer` step is pinned to the `@v3` major tag rather than a commit SHA like every other action in this repo, because the authoring environment cannot reach the `sigstore/cosign-installer` repo to resolve a SHA. A maintainer should replace `@v3` with the exact `<sha> # v3.x.y` pin to match the repo's supply-chain convention.

Trust-phase item (PR-D) from the audit.