### PR TITLE
PR-L: systemd hardening ceiling on all four units

### DIFF
--- a/systemd/hardn-api.service
+++ b/systemd/hardn-api.service
@@ -53,6 +53,27 @@ ProtectSystem=strict
 ReadWritePaths=/var/log/hardn /var/lib/hardn
 
 PrivateTmp=yes
+# Hardening ceiling. The API is an unprivileged (User=hardn) local HTTP
+# service; it takes no privileged actions, so it carries the full
+# SystemCallFilter=@system-service set. MemoryDenyWriteExecute is
+# deliberately OMITTED: CPython and native extensions (psutil) can map
+# W+X pages and MDWX would crash the interpreter. RestrictAddressFamilies
+# is HTTP-only (no netlink). No ProtectProc: psutil reads other
+# processes for the overwatch endpoints.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+PrivateDevices=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/hardn-monitor.service
+++ b/systemd/hardn-monitor.service
@@ -40,6 +40,26 @@ ProtectSystem=strict
 # Allow writes where the monitor stores state / logs
 ReadWritePaths=/var/lib/hardn /var/log/hardn
 PrivateTmp=yes
+# Hardening ceiling. The monitor polls systemctl and curls the local
+# API; it takes no privileged response actions, so it can carry the
+# full SystemCallFilter=@system-service set (which strips @privileged)
+# and MemoryDenyWriteExecute (safe for the Rust binary; no JIT). No
+# ProtectProc: the monitor reads other units' state.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+PrivateDevices=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 
 # Resource limits
 MemoryMax=256M

--- a/systemd/hardn.service
+++ b/systemd/hardn.service
@@ -49,6 +49,27 @@ ProtectHome=yes
 ProtectSystem=strict
 ReadWritePaths=/var/lib/hardn /var/log/hardn
 PrivateTmp=yes
+# Hardening ceiling. These block writes / actions the daemon never
+# performs while leaving reads intact, so LEGION monitoring is
+# unaffected. NOTE: ProtectProc / ProcSubset are deliberately NOT set,
+# because LEGION inspects OTHER processes and hiding /proc would blind
+# it. SystemCallFilter is deliberately NOT set here either: this unit
+# can run LEGION in --response-enabled mode (see EnvironmentFile above),
+# which needs privileged syscalls for firewall edits and process
+# termination. RestrictAddressFamilies keeps AF_NETLINK and AF_PACKET
+# for the network sensor.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK AF_PACKET
+SystemCallArchitectures=native
 
 # Resource limits
 MemoryMax=512M

--- a/systemd/legion-daemon.service
+++ b/systemd/legion-daemon.service
@@ -48,6 +48,23 @@ ProtectHome=yes
 ProtectSystem=strict
 ReadWritePaths=/var/lib/hardn /var/log/hardn
 PrivateTmp=yes
+# Hardening ceiling. Same tuning as hardn.service: reads stay open so
+# LEGION can monitor other processes (no ProtectProc / ProcSubset), and
+# no SystemCallFilter so --response-enabled deployments keep privileged
+# syscalls. RestrictAddressFamilies keeps netlink + packet for the
+# network sensor.
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK AF_PACKET
+SystemCallArchitectures=native
 
 # Resource limits
 MemoryMax=256M

--- a/tests/static/systemd-hardening.t.sh
+++ b/tests/static/systemd-hardening.t.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Pre-push regression guard: shipped units carry a hardening baseline.
+#
+# The audit found all four units at systemd-analyze exposure ~8.5
+# ("EXPOSED") with only the floor directives (NoNewPrivileges,
+# ProtectSystem=strict, ProtectHome, PrivateTmp). This guard locks in
+# the ceiling directives and an exposure-score budget so a future edit
+# cannot silently drop the hardening.
+#
+# Tuning rationale (why not identical across units):
+#   - hardn.service and legion-daemon.service can run LEGION in
+#     --response-enabled mode, which needs privileged syscalls
+#     (firewall edits, killing processes). They therefore do NOT set a
+#     SystemCallFilter that strips @privileged; their budget is looser.
+#   - hardn-monitor.service and hardn-api.service take no privileged
+#     response actions, so they add SystemCallFilter=@system-service and
+#     reach a lower score.
+#   - No unit sets ProtectProc=invisible / ProcSubset=pid: these daemons
+#     inspect OTHER processes, and hiding /proc would blind them.
+#
+# Invariants:
+#
+#   H1  Every unit declares the read-safe ceiling directives:
+#       ProtectKernelTunables, ProtectKernelModules, ProtectControlGroups,
+#       RestrictNamespaces, RestrictRealtime, RestrictSUIDSGID,
+#       LockPersonality, RestrictAddressFamilies.
+#
+#   H2  No unit sets ProtectProc=invisible or ProcSubset=pid (would
+#       break process monitoring).
+#
+#   H3  Each unit's offline exposure score is at or below its budget.
+
+set -u
+
+HARDN_TEST_NAME="static/systemd-hardening"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+require_cmd systemd-analyze "install with: apt-get install systemd"
+
+UNIT_DIR="$REPO_ROOT/systemd"
+
+# Per-unit exposure budget (systemd-analyze security --offline). The
+# response-capable daemons keep privileged syscalls so they sit higher.
+declare -A BUDGET=(
+    [hardn.service]=6.0
+    [legion-daemon.service]=6.0
+    [hardn-monitor.service]=5.0
+    [hardn-api.service]=5.0
+)
+
+REQUIRED_DIRECTIVES=(
+    ProtectKernelTunables
+    ProtectKernelModules
+    ProtectControlGroups
+    RestrictNamespaces
+    RestrictRealtime
+    RestrictSUIDSGID
+    LockPersonality
+    RestrictAddressFamilies
+)
+
+mapfile -t units < <(find "$UNIT_DIR" -type f -name '*.service' | sort)
+
+# Plan: for each unit -> 1 directives assertion + 1 no-ProtectProc +
+# 1 score assertion.
+tap_plan $(( ${#units[@]} * 3 ))
+
+for u in "${units[@]}"; do
+    base=$(basename "$u")
+
+    # H1: required directives present.
+    missing=""
+    for d in "${REQUIRED_DIRECTIVES[@]}"; do
+        if ! grep -qE "^${d}=" "$u"; then
+            missing="$missing $d"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        tap_ok "$base declares the read-safe ceiling directives"
+    else
+        tap_not_ok "$base is missing hardening directives:$missing"
+    fi
+
+    # H2: must not blind itself to other processes.
+    if grep -qE '^(ProtectProc=invisible|ProcSubset=pid)' "$u"; then
+        tap_not_ok "$base must not set ProtectProc=invisible / ProcSubset=pid (breaks process monitoring)"
+    else
+        tap_ok "$base does not hide /proc from itself"
+    fi
+
+    # H3: exposure budget.
+    budget="${BUDGET[$base]:-6.0}"
+    score=$(systemd-analyze security --offline=true "$u" 2>/dev/null \
+        | grep -iE 'Overall exposure' \
+        | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    if [ -z "$score" ]; then
+        tap_not_ok "$base: could not read exposure score from systemd-analyze"
+    elif awk -v s="$score" -v b="$budget" 'BEGIN{exit !(s+0 <= b+0)}'; then
+        tap_ok "$base exposure $score is within budget $budget"
+    else
+        tap_not_ok "$base exposure $score exceeds budget $budget"
+    fi
+done
+
+tap_summary


### PR DESCRIPTION
## Summary

Every shipped unit sat at systemd-analyze exposure ~8.5 ("EXPOSED") with only the floor directives. This adds the ceiling directives, tuned per service so monitoring and response capabilities are preserved.

## Changes

Exposure (`systemd-analyze security --offline`), before to after:

| Unit | Before | After |
|---|---|---|
| hardn.service | 8.7 EXPOSED | **5.9 MEDIUM** |
| legion-daemon.service | 8.7 EXPOSED | **5.9 MEDIUM** |
| hardn-monitor.service | 8.7 EXPOSED | **3.8 OK** |
| hardn-api.service | 8.3 EXPOSED | **3.5 OK** |

**Two tiers, deliberately:**
- **Response daemons** (`hardn.service`, `legion-daemon.service`) run LEGION, which in `--response-enabled` mode needs privileged syscalls. They get the read-safe ceiling + `RestrictAddressFamilies` keeping `AF_NETLINK`/`AF_PACKET` for the network sensor, but **no** `SystemCallFilter` (would strip `@privileged` and break response mode).
- **Non-response daemons** (`hardn-monitor`, `hardn-api`) add `SystemCallFilter=@system-service` + `PrivateDevices`. Monitor (Rust) also gets `MemoryDenyWriteExecute`; API (Python) **omits** it because CPython + psutil can map W+X.

**Deliberately NOT set:** `ProtectProc=invisible` / `ProcSubset=pid` — these daemons inspect other processes; hiding `/proc` would blind them.

## Testing

- `systemd-analyze verify` on all 4 units: no syntax errors
- Guard `systemd-hardening.t.sh` 12/12; `systemd-verify.t.sh` 4/4
- `bash tests/run-all.sh`: 32 suites, 250 pass, 0 fail, 1 skip

## Note

A maintainer with a live host should boot-smoke `hardn.service` (observe, and `--response-enabled`) to confirm the address-family/namespace restrictions don't block the network sensor or response actions. The `ci.yml` container integration test exercises startup as an automated backstop.