### PR TITLE
Make release publishing atomic: no tag or release if signing fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,18 +370,14 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Calculated next tag: $NEW_TAG (from $LATEST_TAG)"
 
-      - name: Create and push release tag
-        run: |
-          NEW_TAG="${{ steps.tag.outputs.new_tag }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-            echo "Tag $NEW_TAG already exists; skipping creation."
-          else
-            git tag "$NEW_TAG"
-            git push https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/Security-International-Group/HARDN.git "$NEW_TAG"
-          fi
+      # NOTE: the release tag is intentionally NOT pushed here. It used to be
+      # created before signing, so a failed cosign step (or any later failure)
+      # left an orphan tag with no release attached and bumped the version
+      # counter. The tag is now created atomically by the "Create GitHub
+      # Release" step below (softprops creates tag_name at target_commitish
+      # when it does not yet exist). If signing or any prior step fails, the
+      # release action never runs, so no tag and no release are produced and
+      # the job fails red.
 
       - name: Generate release notes
         id: notes
@@ -498,12 +494,14 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             release_assets/*.deb
-            release_assets/IMG_1233.jpeg
             release_assets/SHA256SUMS
             release_assets/SHA256SUMS.sig
             release_assets/SHA256SUMS.pem
             release_assets/*.deb.sig
             release_assets/*.deb.pem
+          # Every listed file is produced by the sign step and must exist;
+          # fail the release rather than publish a partial asset set.
+          fail_on_unmatched_files: true
           draft: false
           prerelease: false
         env:

--- a/tests/static/release-signing.t.sh
+++ b/tests/static/release-signing.t.sh
@@ -37,7 +37,7 @@ CI="$REPO_ROOT/.github/workflows/ci.yml"
 
 assert_file_exists "$CI" ".github/workflows/ci.yml ships"
 
-tap_plan 7
+tap_plan 10
 
 # S1: cosign installer present.
 if grep -qE 'sigstore/cosign-installer' "$CI"; then
@@ -95,6 +95,36 @@ if grep -nE 'sha256sum[^#]*IMG_1233\.jpeg' "$CI" >/dev/null 2>&1; then
     grep -nE 'sha256sum[^#]*IMG_1233\.jpeg' "$CI" | sed 's/^/# /'
 else
     tap_ok "sha256sum does not reference the release-job-absent IMG_1233.jpeg"
+fi
+
+# S8: no manual git-tag push. The tag used to be pushed BEFORE signing, so a
+# failed sign orphaned a tag and bumped the version counter. Tag creation is
+# now delegated to the release action, which runs only after signing. A
+# 'git push ... "$NEW_TAG"' anywhere reintroduces the orphan-tag hazard.
+if grep -nE 'git[[:space:]]+push[^#\n]*NEW_TAG' "$CI" >/dev/null 2>&1; then
+    tap_not_ok "release job must not manually push the tag before signing"
+    grep -nE 'git[[:space:]]+push[^#\n]*NEW_TAG' "$CI" | sed 's/^/# /'
+else
+    tap_ok "release tag is not manually pushed (created atomically by the release step)"
+fi
+
+# S9: signing must come BEFORE the GitHub Release publish step, so a signing
+# failure prevents any release from being created.
+sign_line=$(grep -nE 'cosign[[:space:]]+sign-blob' "$CI" | head -1 | cut -d: -f1)
+release_line=$(grep -nE 'softprops/action-gh-release' "$CI" | head -1 | cut -d: -f1)
+if [ -n "$sign_line" ] && [ -n "$release_line" ] && [ "$sign_line" -lt "$release_line" ]; then
+    tap_ok "cosign signing runs before the GitHub Release publish step"
+else
+    tap_not_ok "cosign signing must run before the release publish step"
+    tap_diag "sign at line ${sign_line:-none}, release at line ${release_line:-none}"
+fi
+
+# S10: the release upload must fail on a missing asset rather than publish a
+# partial set. Every listed file is produced by the sign step and must exist.
+if grep -qE 'fail_on_unmatched_files:[[:space:]]*true' "$CI"; then
+    tap_ok "release upload fails on an unmatched (missing) asset"
+else
+    tap_not_ok "release must set fail_on_unmatched_files: true so a partial asset set fails"
 fi
 
 tap_summary


### PR DESCRIPTION
## Summary

The release job pushed the git tag **before** the cosign signing step, so a failed sign (or any later failure) left an orphan tag with no release attached and bumped the version counter — this bit the v1.2.134 build. This makes tag + release atomic so a failure produces neither.

## Changes

- **Deleted the manual "Create and push release tag" step.** `softprops/action-gh-release` creates `tag_name` at `target_commitish` when it doesn't already exist, so the tag and release are produced together as the final step. If signing or any prior step fails, the release action never runs.
- **Removed `release_assets/IMG_1233.jpeg`** from the upload list — that file is added by the deploy-test job, not the release job, so it's absent here (same class as the sha256sum bug fixed for v1.2.134).
- **Set `fail_on_unmatched_files: true`** so a missing signature/checksum fails the release instead of publishing a partial, unverifiable asset set.

## Failure containment — what "no release if anything fails" now means

| Failure | Result |
|---|---|
| build fails | deploy-test and release never run (`needs:`) |
| integration test fails | release never runs (`needs: deploy-test`) |
| sign / checksum fails | release action never runs → no tag, no release, job red |
| missing asset | release action fails → no release, job red |

## Testing

- YAML lint on `ci.yml`
- Guard `release-signing.t.sh` extended: S8 (no manual tag push), S9 (signing before publish), S10 (`fail_on_unmatched_files: true`) — 11/11
- `bash tests/run-all.sh`: 34 suites, 268 assertions, 267 pass, 0 fail, 1 skip

## Note

The orphan tag `v1.2.134` from the earlier failed run still exists (harmless; next release computes `v1.2.135`). Can be deleted manually if you want it gone.