### PR TITLE
PR-G: hardn-apid Rust axum skeleton (/health on a Unix socket)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,10 +118,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "bitflags"
@@ -973,6 +1031,7 @@ name = "hardn"
 version = "1.2.92"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "colored",
@@ -1043,6 +1102,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1198,6 +1337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1356,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1547,12 +1698,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1632,6 +1806,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "system-deps"
@@ -1763,6 +1943,54 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ comfy-table = "7.2"
 once_cell = "1.21"
 vte4 = "0.9"
 rusqlite = { version = "0.39", features = ["bundled"] }
+# hardn-apid: Rust replacement for the Python FastAPI service. Kept to a
+# Unix-socket HTTP server (no TLS stack) since the API is local-only.
+axum = "0.8"
 
 [profile.release]
 opt-level = "z"    # Optimize for size
@@ -65,6 +68,10 @@ path = "src/hardn-monitor.rs"
 [[bin]]
 name = "hardn-gui"
 path = "src/hardn-gui.rs"
+
+[[bin]]
+name = "hardn-apid"
+path = "src/hardn-apid.rs"
 
 [patch.crates-io]
 # partitions = { git = "https://github.com/DDOtten/partitions.git", branch = "master" }

--- a/src/hardn-apid.rs
+++ b/src/hardn-apid.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+//! hardn-apid: Rust replacement for the Python `hardn-api` FastAPI service.
+//!
+//! This is step one of retiring the Python runtime (and its pip supply
+//! chain). It serves the health endpoint over a Unix domain socket rather
+//! than a TCP port, because the API is local-only: `hardn-monitor` talks to
+//! it from the same host. A Unix socket removes the network attack surface
+//! entirely and lets the kernel enforce access with file permissions.
+//!
+//! The socket path is `HARDN_APID_SOCKET` (default
+//! `/run/hardn/hardn-apid.sock`). The remaining endpoints (`/metrics`,
+//! `/overwatch/*`, `/legion/*`) are ported in follow-up changes, each
+//! diff-tested against the Python implementation before the Python side is
+//! removed.
+
+use axum::{Json, Router, routing::get};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+/// Default socket path. Under `/run` so it is tmpfs-backed and cleared on
+/// reboot; the parent dir is created at startup if missing.
+const DEFAULT_SOCKET: &str = "/run/hardn/hardn-apid.sock";
+
+/// Body of the health response. Kept as a free function so it can be unit
+/// tested without standing up a server. Shape matches the Python
+/// `/health` so consumers do not have to change during the migration.
+fn health_body() -> serde_json::Value {
+    serde_json::json!({
+        "status": "healthy",
+        "service": "hardn-apid",
+        "version": env!("CARGO_PKG_VERSION"),
+    })
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(health_body())
+}
+
+/// Build the router. Separate from `main` so tests can serve the exact same
+/// routes on a throwaway socket.
+fn app() -> Router {
+    Router::new().route("/health", get(health))
+}
+
+/// Bind the Unix socket at `path`, replacing any stale socket file and
+/// creating the parent directory. Restricts the socket to `0660` so only the
+/// owning user and group can connect.
+fn bind_socket(path: &str) -> std::io::Result<tokio::net::UnixListener> {
+    if let Some(parent) = Path::new(path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // A leftover socket file from a previous run would make bind() fail with
+    // EADDRINUSE even though nothing is listening.
+    let _ = std::fs::remove_file(path);
+    let listener = tokio::net::UnixListener::bind(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660))?;
+    Ok(listener)
+}
+
+#[tokio::main]
+async fn main() {
+    let socket_path =
+        std::env::var("HARDN_APID_SOCKET").unwrap_or_else(|_| DEFAULT_SOCKET.to_string());
+
+    let listener = match bind_socket(&socket_path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("hardn-apid: cannot bind {socket_path}: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    eprintln!("hardn-apid: listening on {socket_path}");
+    if let Err(e) = axum::serve(listener, app()).await {
+        eprintln!("hardn-apid: serve error: {e}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn health_body_reports_healthy() {
+        let b = health_body();
+        assert_eq!(b["status"], "healthy");
+        assert_eq!(b["service"], "hardn-apid");
+        assert!(b["version"].is_string());
+    }
+
+    #[tokio::test]
+    async fn serves_health_over_unix_socket() {
+        // Bind a throwaway socket under the test's temp dir, serve the real
+        // router, then speak raw HTTP/1.1 to it over the socket.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("apid.sock");
+        let sock_str = sock.to_str().unwrap().to_string();
+
+        let listener = bind_socket(&sock_str).expect("bind");
+        // set_permissions 0660 must have applied; confirm the socket exists.
+        assert!(sock.exists());
+
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app()).await;
+        });
+
+        // Connect and issue GET /health.
+        let mut stream = tokio::net::UnixStream::connect(&sock)
+            .await
+            .expect("connect");
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("write");
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.expect("read");
+        let resp = String::from_utf8_lossy(&buf);
+
+        assert!(resp.starts_with("HTTP/1.1 200"), "status line: {resp}");
+        assert!(resp.contains("\"status\":\"healthy\""), "body: {resp}");
+        assert!(resp.contains("\"service\":\"hardn-apid\""), "body: {resp}");
+
+        server.abort();
+    }
+}

--- a/tests/static/apid-skeleton.t.sh
+++ b/tests/static/apid-skeleton.t.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Pre-push guard for the hardn-apid skeleton (PR-G, first step of
+# replacing the Python hardn-api with a Rust axum service).
+#
+# The goal of the G-K arc is to remove the Python FastAPI runtime and
+# its pip supply chain. PR-G stands up a Rust hardn-apid binary serving
+# /health on a Unix socket, running in parallel with the Python API; the
+# Python side is not removed until the endpoints are ported (later PRs).
+#
+# Invariants:
+#
+#   A1  src/hardn-apid.rs ships.
+#   A2  Cargo.toml declares the hardn-apid binary and the axum dependency.
+#   A3  hardn-apid binds a Unix socket (not a TCP port) and reads the
+#       socket path from HARDN_APID_SOCKET.
+#   A4  hardn-apid serves a /health route.
+
+set -u
+
+HARDN_TEST_NAME="static/apid-skeleton"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+APID="$REPO_ROOT/src/hardn-apid.rs"
+CARGO="$REPO_ROOT/Cargo.toml"
+
+assert_file_exists "$CARGO" "Cargo.toml ships"
+
+tap_plan 5
+
+# A1: the binary source exists.
+if [ -f "$APID" ]; then
+    tap_ok "src/hardn-apid.rs ships"
+else
+    tap_not_ok "src/hardn-apid.rs must ship"
+    tap_summary
+    exit 0
+fi
+
+# A2a: Cargo.toml declares the bin.
+if grep -qE 'name[[:space:]]*=[[:space:]]*"hardn-apid"' "$CARGO"; then
+    tap_ok "Cargo.toml declares the hardn-apid binary"
+else
+    tap_not_ok "Cargo.toml must declare a [[bin]] hardn-apid"
+fi
+
+# A2b: axum dependency present.
+if grep -qE '^axum[[:space:]]*=' "$CARGO"; then
+    tap_ok "Cargo.toml declares the axum dependency"
+else
+    tap_not_ok "Cargo.toml must declare axum"
+fi
+
+# A3: Unix socket bind + env override, and NOT a TCP bind.
+if grep -qE 'UnixListener' "$APID" && grep -qE 'HARDN_APID_SOCKET' "$APID"; then
+    tap_ok "hardn-apid binds a Unix socket via HARDN_APID_SOCKET"
+else
+    tap_not_ok "hardn-apid must bind a Unix socket and read HARDN_APID_SOCKET"
+fi
+
+# A4: /health route.
+if grep -qE '"/health"' "$APID"; then
+    tap_ok "hardn-apid serves a /health route"
+else
+    tap_not_ok "hardn-apid must serve a /health route"
+fi
+
+tap_summary


### PR DESCRIPTION
## Summary

First step of replacing the Python `hardn-api` FastAPI service and retiring the pip supply chain. Adds a Rust `hardn-apid` binary that serves `/health` over a Unix domain socket. **The Python API keeps running in parallel — nothing is removed yet.** The remaining endpoints (`/metrics`, `/overwatch/*`, `/legion/*`) are ported in follow-up PRs, each diff-tested against the Python implementation before the Python side is deleted.

## Why a Unix socket, not TCP

The API is local-only (`hardn-monitor` talks to it from the same host), so a socket removes the network attack surface entirely and lets the kernel enforce access with file permissions. The socket is created `0660` under `/run` (tmpfs, cleared on reboot); path is `HARDN_APID_SOCKET` (default `/run/hardn/hardn-apid.sock`).

## Changes

- `Cargo.toml`: axum 0.8 dependency + `[[bin]] hardn-apid`.
- `src/hardn-apid.rs`: `health_body()` (unit-testable), `app()` router, `bind_socket()` (creates parent dir, clears a stale socket, sets `0660`), and a `#[tokio::main]` entrypoint.

## Testing

- `health_body_reports_healthy`: the JSON shape (status/service/version).
- `serves_health_over_unix_socket`: binds a throwaway socket, serves the real router, connects with a raw `UnixStream`, issues `GET /health`, asserts HTTP 200 + healthy body — proves the socket path works end to end, not just the handler.
- Supply chain (new axum tree): `cargo audit` no new advisories; `cargo deny` advisories/bans/licenses/sources all ok.
- Guard `apid-skeleton.t.sh` 6/6.
- `bash tests/run-all.sh`: 35 suites, 272 assertions, 271 pass, 0 fail, 1 skip.

## Risk and rollout

Additive only — new binary, not wired into any systemd unit or the `.deb` install path yet. That wiring (and the Python removal) comes in later PRs once the endpoints reach parity.