### PR TITLE
docs: fix README quick-start so `hardn` is actually installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ binary with no continuous-monitoring daemon and no desktop application.
 ## Quick start
 
 ```bash
-# Build the CLI and the audit engine
-cargo build --release
-cc -std=c11 -O2 src/audit/hardn_audit.c -o target/release/hardn-audit
+# Clone, build the Debian package, and install it. `sudo make hardn`
+# builds first, then installs `hardn` and `hardn-audit` onto your PATH.
+git clone https://github.com/Security-International-Group/HARDN.git
+cd HARDN
+sudo make build
+sudo make hardn
 
 # Run a compliance audit (writes the report)
 sudo hardn audit          # or: sudo hardn --security-report
@@ -46,6 +49,11 @@ sudo hardn audit          # or: sudo hardn --security-report
 # Launch the local console
 hardn serve               # http://127.0.0.1:8000
 ```
+
+Building without installing? `cargo build --release` and
+`cc -std=c11 -O2 src/audit/hardn_audit.c -o target/release/hardn-audit`
+produce the binaries under `target/release/`; run them by path
+(`sudo ./target/release/hardn audit`) since they are not on `PATH`.
 
 `hardn serve` prints an **operator** and a **viewer** URL, each with a one-time
 token. Open the operator URL in a browser on the same machine; the token


### PR DESCRIPTION
## Summary

Follow-up to #225. The README Quick Start built the binaries with `cargo build --release` + `cc` (which only produce `target/release/hardn` and `target/release/hardn-audit`) and then told the reader to run `sudo hardn audit` and `hardn serve`. **That fails** — nothing installed `hardn` onto `PATH`, so the command is not found.

## Fix

Quick Start now uses the real install flow, matching `docs/hardn.md`:

```bash
git clone https://github.com/Security-International-Group/HARDN.git
cd HARDN
sudo make build     # builds the .deb
sudo make hardn     # builds (dependency) + installs hardn + hardn-audit
```

After `sudo make hardn`, `sudo hardn audit` and `hardn serve` resolve on `PATH`. The raw `cargo`/`cc` path is kept as an explicit "build without installing" note that tells you to run the binaries by path.

## Verification

Checked in the `Makefile`: `hardn: build`, and the install path compiles `src/audit/hardn_audit.c` and runs `install -m 755 target/release/hardn-audit /usr/lib/hardn/hardn-audit` — exactly the `HARDN_AUDIT_BIN` fallback the console uses. `doc-hygiene.t.sh` 3/3.

Thanks for catching this — the broken Quick Start predates #225 and I missed it in that pass.