### PR TITLE
fix(audit): pwquality parser dropped options whose key contains 't'

### DIFF
--- a/src/audit/hardn_audit.c
+++ b/src/audit/hardn_audit.c
@@ -227,7 +227,7 @@ static void parse_pwquality_line(pam_pwquality_config_t *cfg, const char *line) 
 
     char *dup = strdup(line);
     if (!dup) return;
-    char *token = strtok(dup, " \\t");
+    char *token = strtok(dup, " \t");
     while (token) {
         char *eq = strchr(token, '=');
         if (eq) {
@@ -236,7 +236,7 @@ static void parse_pwquality_line(pam_pwquality_config_t *cfg, const char *line) 
             const char *value = eq + 1;
             apply_pwquality_option(cfg, key, value);
         }
-        token = strtok(NULL, " \\t");
+        token = strtok(NULL, " \t");
     }
     free(dup);
 }

--- a/tests/unit/pwquality-parse.t.sh
+++ b/tests/unit/pwquality-parse.t.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# parse_pwquality_line must populate every pam_pwquality option from a
+# realistic PAM line, including the ones whose key contains a 't'
+# (dcredit/ucredit/lcredit/ocredit/retry). Regression guard for the strtok
+# delimiter bug that split tokens on 't' and dropped those options.
+
+set -u
+
+HARDN_TEST_NAME="unit/pwquality-parse"
+SUITE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/.." && pwd)"
+
+# shellcheck source=../lib/assert.sh
+source "$SUITE_DIR/lib/assert.sh"
+
+require_cmd cc "install a C compiler"
+
+SRC="$REPO_ROOT/tests/unit/pwquality_parse_test.c"
+if [ ! -f "$SRC" ]; then
+    tap_plan 1
+    tap_not_ok "pwquality_parse_test.c missing"
+    tap_summary
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+if ! cc -std=c11 -O1 -w "$SRC" -o "$WORK/t" 2>"$WORK/build.log"; then
+    tap_plan 1
+    tap_not_ok "pwquality parse test failed to compile"
+    sed 's/^/# /' "$WORK/build.log" | head -20
+    tap_summary
+    exit 1
+fi
+
+out="$("$WORK/t")"
+val() { printf '%s\n' "$out" | sed -n "s/^$1=//p"; }
+
+tap_plan 8
+
+assert_eq "1"  "$(val found)"    "line recognized as a pam_pwquality rule"
+assert_eq "3"  "$(val retry)"    "retry parsed (key contains 't')"
+assert_eq "12" "$(val minlen)"   "minlen parsed"
+assert_eq "-1" "$(val dcredit)"  "dcredit parsed (key contains 't')"
+assert_eq "-2" "$(val ucredit)"  "ucredit parsed (key contains 't')"
+assert_eq "-1" "$(val lcredit)"  "lcredit parsed (key contains 't')"
+assert_eq "-1" "$(val ocredit)"  "ocredit parsed (key contains 't')"
+assert_eq "4"  "$(val minclass)" "minclass parsed"
+
+tap_summary

--- a/tests/unit/pwquality_parse_test.c
+++ b/tests/unit/pwquality_parse_test.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Unit test for parse_pwquality_line(). A realistic pam_pwquality.so line
+ * must populate every option, including the keys that contain the letter
+ * 't' (dcredit/ucredit/lcredit/ocredit/retry). Regression cover for the
+ * strtok delimiter bug where the separator string was " \\t" (space,
+ * backslash, literal 't') instead of a tab, which split tokens on any 't'
+ * and silently dropped those options.
+ *
+ * Prints the parsed values one per line so the TAP wrapper can compare and
+ * show the actual (wrong) value on failure.
+ */
+#define HARDN_NO_MAIN
+#include "../../src/audit/hardn_audit.c"
+#include <stdio.h>
+
+int main(void) {
+    pam_pwquality_config_t cfg;
+    init_pwquality_config(&cfg);
+    parse_pwquality_line(
+        &cfg,
+        "password requisite pam_pwquality.so retry=3 minlen=12 dcredit=-1 "
+        "ucredit=-2 lcredit=-1 ocredit=-1 minclass=4");
+    printf("found=%d\n", cfg.found ? 1 : 0);
+    printf("retry=%ld\n", cfg.retry);
+    printf("minlen=%ld\n", cfg.minlen);
+    printf("dcredit=%ld\n", cfg.dcredit);
+    printf("ucredit=%ld\n", cfg.ucredit);
+    printf("lcredit=%ld\n", cfg.lcredit);
+    printf("ocredit=%ld\n", cfg.ocredit);
+    printf("minclass=%ld\n", cfg.minclass);
+    return 0;
+}


### PR DESCRIPTION
## Summary

The fuzzing work (#228) surfaced a real correctness bug in the audit engine's PAM parser.

`parse_pwquality_line()` tokenized the line with `strtok(dup, " \\t")`. In C source `" \\t"` is **three** characters — space, backslash, and a literal `t` — not the intended space+tab. So `strtok` split tokens on any `t`, mangling every option key that contains one:

| Option | Has `t`? | Parsed before fix? |
|---|---|---|
| `minlen` | no | yes |
| `minclass` | no | yes |
| `dcredit` / `ucredit` / `lcredit` / `ocredit` | yes | no — dropped |
| `retry` | yes | no — dropped |

The dropped options stayed at their `LONG_MIN` "unset" sentinel, so the corresponding audit rules would report **configured** pwquality settings as missing — a false finding on a correctly hardened host.

## Fix

One character, both `strtok` calls: `" \\t"` → `" \t"`.

## Regression test (added failing, now passing)

- `tests/unit/pwquality_parse_test.c` — `#include`s the engine (`HARDN_NO_MAIN`, the guard from #228) and calls `parse_pwquality_line` on a realistic line.
- `tests/unit/pwquality-parse.t.sh` — asserts every option parses: `retry=3 minlen=12 dcredit=-1 ucredit=-2 lcredit=-1 ocredit=-1 minclass=4`.

**Before the fix:** the five `t`-keys returned `LONG_MIN` → **5 of 8 assertions failed.** **After:** 8/8.

## Testing

- `tests/unit/pwquality-parse.t.sh` → 8/8
- `cc -Wall src/audit/hardn_audit.c` → clean
- `tests/integration/audit-fuzz.t.sh` → still 3/3 (fix survives the sanitizer harness)
- `bash tests/run-all.sh` → 24 suites, 141 pass, 0 fail, 3 skip

Depends on #228 (merged) for the `HARDN_NO_MAIN` guard the unit test uses.