### PR TITLE
Combine dependabot prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,7 @@ jobs:
           } >> RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.tag.outputs.new_tag }}
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
       - name: Cache cargo registry and git
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
       - name: Cache cargo registry and git
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Cache scanner binaries
         id: cache-scanners
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/bin/cargo-audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,7 +68,7 @@ jobs:
           cargo build --release
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: /language:${{ matrix.language }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
       - name: Cache cargo registry and git
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary

This PR updates the pinned SHAs for 4 different GitHub actions.

## Changes

<!-- Bullet the concrete changes. Reference files or subsystems. -->

- Pin actions/cache to v6.1.0
- Pin github/codeql-action/analyze to SHA for newer release v4.37.1
- Pin github/codeql-action/init to SHA for newer release v4.37.1
- Pin softprops/action-gh-release to SHA for latest release v3.0.2

## Testing

OpenSSF Scorecard was used to look up a score for `softprops/action-gh-release`.
Result: Aggregate score: 6.5 / 10

That was followed up with a similar inquiry with Claude Code, resulting in the following:
```
Pulled the actual breakdown. Current score is 5.5/10 (scorecard.dev, checked just now — may have shifted slightly from whatever you saw). Here's what's actually driving it:

┌─────────────────────┬───────┬─────────────────────────────────────┐
│        Check        │ Score │               Meaning               │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Branch-Protection   │ 0     │ confirmed — no protection on master │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Code-Review         │ 0     │ "Found 1/14 approved changesets"    │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Security-Policy     │ 0     │ no SECURITY.md                      │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ SAST                │ 0     │ no static analysis in CI            │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Fuzzing             │ 0     │ not fuzzed                          │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ CII-Best-Practices  │ 0     │ no OpenSSF badge effort             │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Signed-Releases     │ -1    │ "no releases found" (see below)     │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Packaging           │ -1    │ not applicable                      │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Pinned-Dependencies │ 10    │ their CI pins its own deps          │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Token-Permissions   │ 10    │ least-privilege tokens              │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Dangerous-Workflow  │ 10    │ no injection patterns               │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ Maintained          │ 10    │ active — 30 commits/90 days         │
├─────────────────────┼───────┼─────────────────────────────────────┤
│ License             │ 10    │ MIT                                 │
└─────────────────────┴───────┴─────────────────────────────────────┘

The one that should actually worry you more than branch protection is Code-Review: 1/14. That means 13 of the last 14 changesets landed with no second person approving them — almost everything is self-merged by the maintainer. Combined with zero branch protection, there is effectively no independent-review gate on this repo at all. One compromised or phished maintainer account, and malicious code ships with nobody else in the loop to catch it. That's the concrete mechanism, not an abstract score.

Don't over-weight the -1s (Signed-Releases, Packaging) — those mean "not applicable/not detected infrastructure," not "failed." A GH Action repo that doesn't publish standalone binaries will naturally show -1 there; it's not a real signal either way.

Context that matters: this repo is legit and heavily used — 5,709 stars, node24 action with committed dist/index.js (same pattern as actions/cache), actively maintained, no dangerous workflow patterns, decent token hygiene in its own CI. It's a single-maintainer-style project (softprops, with chenrui333 cutting the latest v3.0.2 release July 13, 2026) — the low review/branch-protection scores are typical of solo/small-maintainer OSS, not unique badness. Most single-maintainer actions in the ecosystem score exactly this way; it's a structural reality of that trust model, not a red flag specific to this project.

What this means practically for you:
1. SHA-pin, non-negotiably. With zero branch protection and near-zero review, a tag repoint or direct push wouldn't be caught by anyone but you.
2. Verify dist/index.js is reproducible for the SHA you pin — build from source and diff, since there's no CI-enforced build/release verification here either.
3. Treat this as: "high-value target (popular) + minimal internal review gates" — a genuinely elevated risk class compared to actions/cache, worth SHA-pinning and periodically re-diffing on updates rather than "set and forget."
```

## Risk and rollout

Updating the pinned releases for the GitHub owned actions "safer" than the third party action from `softprops`.
Important to realize the potential for supply chain attacks, however, pinning releases to SHAs and manually verifying the legitimacy of the latest releases helps to at least somewhat mitigate risks, however, risks are still present from the connected outside sources.

## Related

These changes are made based on the updates proposed by dependabot in the following closes PRs:
#213 #220 #221 #222 
